### PR TITLE
GNC: bug fixes at lake day, and PD tuning

### DIFF
--- a/gnc/navigator_thrust_allocater/src/p_driver.py
+++ b/gnc/navigator_thrust_allocater/src/p_driver.py
@@ -158,7 +158,7 @@ class P_Driver(object):
 if __name__ == "__main__":
 
 
-    rate = rospy.Rate(10)
+    rate = rospy.Rate(50)
     # Create two thrusters
     BL = Thruster(thruster_BR_cog, thruster_BR_theta)
     BR = Thruster(thruster_BL_cog, thruster_BL_theta)

--- a/simulation/navigator_sim/navigator_sim_rendering/src/navigator_sim_rendering/sim_rendering_helpers.py
+++ b/simulation/navigator_sim/navigator_sim_rendering/src/navigator_sim_rendering/sim_rendering_helpers.py
@@ -14,7 +14,6 @@ from OpenGL.arrays import vbo
 import pygame
 
 import roslib
-roslib.load_manifest('murph_sim_rendering')
 import rospy
 import tf
 from tf import transformations

--- a/utils/navigator_tools/navigator_tools/move_helper.py
+++ b/utils/navigator_tools/navigator_tools/move_helper.py
@@ -29,7 +29,7 @@ class move_helper(object):
         theta = gh.quat_to_euler(self.odom.pose.pose.orientation)
         to_send.x = self.odom.pose.pose.position.x + msg.x
         to_send.y = self.odom.pose.pose.position.y + msg.y
-        to_send.z = theta[2] + msg.z
+        to_send.z = np.rad2deg(theta[2]) + msg.z
 
         self.pose_pub.publish(to_send)
 


### PR DESCRIPTION
Bugs fixed:

- move_helper function had current yaw in radians but accepted the yaw delta value in degrees
- thruster allocator call rate needed to be 50 Hz
- MRAC controller was multiplying gains and errors with * instead of np.dot
- weird murph_sim dependency in simulator didn't need to be there

Also:

- finished MRAC controller documentation
- tuned the PD parts of the MRAC controller at the lake