### PR TITLE
THRUSTERS and SIM: fix thruster ordering, add effort scaling, fix B-matrix, update sim

### DIFF
--- a/gnc/navigator_controller/src/mrac_controller.py
+++ b/gnc/navigator_controller/src/mrac_controller.py
@@ -124,17 +124,17 @@ class MRAC_Controller:
         self.thrust_max = 220  # N
         self.thruster_positions = np.array([[-1.9000,  1.0000, -0.0123],
                                             [-1.9000, -1.0000, -0.0123],
-                                            [ 1.6000, -0.6000, -0.0123],
-                                            [ 1.6000,  0.6000, -0.0123]]) # back-left, back-right, front-right front-left, m
+                                            [ 1.6000,  0.6000, -0.0123],
+                                            [ 1.6000, -0.6000, -0.0123]]) # back-left, back-right, front-left front-right, m
         self.thruster_directions = np.array([[ 0.7071,  0.7071,  0.0000],
                                              [ 0.7071, -0.7071,  0.0000],
-                                             [ 0.7071,  0.7071,  0.0000],
-                                             [ 0.7071, -0.7071,  0.0000]]) # back-left, back-right, front-right front-left
+                                             [ 0.7071, -0.7071,  0.0000],
+                                             [ 0.7071,  0.7071,  0.0000]]) # back-left, back-right, front-left front-right
         self.lever_arms = np.cross(self.thruster_positions, self.thruster_directions)
         self.B_body = np.concatenate((self.thruster_directions.T, self.lever_arms.T))
         self.Fx_max_body = self.B_body.dot(self.thrust_max * np.array([1, 1, 1, 1]))
-        self.Fy_max_body = self.B_body.dot(self.thrust_max * np.array([1, -1, 1, -1]))
-        self.Mz_max_body = self.B_body.dot(self.thrust_max * np.array([-1, 1, 1, -1]))
+        self.Fy_max_body = self.B_body.dot(self.thrust_max * np.array([1, -1, -1, 1]))
+        self.Mz_max_body = self.B_body.dot(self.thrust_max * np.array([-1, 1, -1, 1]))
         self.D_body = abs(np.array([self.Fx_max_body[0], self.Fy_max_body[1], self.Mz_max_body[5]])) / self.vel_max_body**2
 
         #### BASIC INITIALIZATIONS

--- a/gnc/navigator_thrust_mapper/src/thrust_mapper.py
+++ b/gnc/navigator_thrust_mapper/src/thrust_mapper.py
@@ -32,6 +32,8 @@ BR = Back Right
 FL = Front Left
 FR = Front Right
 
+^ in that order (top to bottom), it's also alphabetical if you forget
+
 Bibliography:
     [1] Christiaan De Wit
         "Optimal Thrust Allocation Methods for Dynamic Positioning of Ships"
@@ -48,24 +50,29 @@ from geometry_msgs.msg import WrenchStamped
 from std_msgs.msg import Float32MultiArray, Bool
 from roboteq_msgs.msg import *
 
+
 class Thruster(object):
 
-    def __init__(self, cog, theda_constraint):
-        self.thruster_cog = np.array(([cog[0], cog[1]]))
-        self.angle_constrain = theda_constraint
+    def __init__(self, cog, angle):
+        self.cog = np.array([cog[0], cog[1]])
+        self.angle = angle
+
 
 class Mapper(object):
 
-    def __init__(self, positions, thrust_limit):
+    def __init__(self, positions, angles, effort_ratio, effort_limit):
 
+        self.boat_cog = np.zeros(2)
+        self.des_force = np.zeros(3)
 
-        self.boat_cog = np.array(([0.0,0.0]))
-        self.des_force = np.array(([0,0,0])).astype(np.float32)
-
-        # list of thruster positions (x,y,theda) in the body frame
+        # list of thruster positions (x,y,theta) in the body frame
         self.positions = positions
-        # Thrust limit used in the clip_thrust() function
-        self.thrust_limit = thrust_limit
+        # list of thruster angles in body frame
+        self.angles = angles
+        # conversion from newtons to firmware units, measured during thruster testing
+        self.effort_ratio = effort_ratio
+        # limit for the value sent to motor driver firmware
+        self.effort_limit = effort_limit
 
         # ROS data
         self.BL_pub = rospy.Publisher("/BL_motor/cmd" , Command, queue_size = 1)
@@ -84,87 +91,82 @@ class Mapper(object):
         # Set desired force and torque as numpy array
         self.des_force = np.array((force.x, force.y, torque.z))
 
-    def thrust_matrix(self, angles):
+    def thrust_matrix(self):
         ''' Iterate through thruster positions and create thruster trans matrix'''
 
         thruster_matrix = []
-        count = 0
         # loop through all sub positions and compute collumns of A
-        for thruster, position in enumerate(self.positions):
+        for thruster_number, position in enumerate(self.positions):
             # l_x and l_y are the offset for the center of gravity
             l_x, l_y = np.subtract(position, self.boat_cog)
             # sin and cos of the angle of the thrusters
-            cos = np.cos(angles[count])
-            sin = np.sin(angles[count])
-            torque_effect = np.cross((l_x, l_y), (cos, -sin))
+            cos = np.cos(self.angles[thruster_number])
+            sin = np.sin(self.angles[thruster_number])
+            torque_effect = np.cross((l_x, l_y), (cos, sin))
             # must transpose to stack correctly
-            thruster_column = np.transpose(np.array([[ cos, -sin, torque_effect]]))
+            thruster_column = np.transpose(np.array([[cos, sin, torque_effect]]))
             thruster_matrix.append(thruster_column)
-            count += 1
 
         # returns a matrix made of the thruster collumns
         return np.hstack(thruster_matrix)
 
-    def allocate(self, angles):
+    def allocate(self):
         ''' Solve for thrust vectors after creating trans matrix '''
 
-        def clip_thrust(thrust):
-            new_thrust = thrust
-            if thrust > self.thrust_limit:
-                new_thrust = self.thrust_limit
-            return new_thrust
-
         # create thrust matrix
-        A = self.thrust_matrix(angles)
+        A = self.thrust_matrix()
         b = self.des_force
 
         # solve Ax = b
         # solutions are given respectively by thruster pose
-        br, bl, fl, fr = np.linalg.lstsq(A, b)[0]
+        bl, br, fl, fr = np.linalg.lstsq(A, b)[0]
 
         # Temporarily sending the left thruster command to the motor driver
         BL_msg, BR_msg, FL_msg, FR_msg = Command(), Command(), Command(), Command()
 
-        # Clip thrust and assign ro ROS messages
-        BL_msg.setpoint = clip_thrust(bl)
-        BR_msg.setpoint = clip_thrust(br)
-        FL_msg.setpoint = clip_thrust(fl)
-        FR_msg.setpoint = clip_thrust(fr)
+        # convert thrusts (in newtons) to effort values (in firmware units)
+        # clip them to firmware limits
+        # assign to ROS messages
+        BL_msg.setpoint = np.clip(bl * self.effort_ratio, -self.effort_limit, self.effort_limit)
+        BR_msg.setpoint = np.clip(br * self.effort_ratio, -self.effort_limit, self.effort_limit)
+        FL_msg.setpoint = np.clip(fl * self.effort_ratio, -self.effort_limit, self.effort_limit)
+        FR_msg.setpoint = np.clip(fr * self.effort_ratio, -self.effort_limit, self.effort_limit)
 
+        # publish ROS messages
         self.BL_pub.publish(BL_msg)
         self.BR_pub.publish(BR_msg)
         self.FL_pub.publish(FL_msg)
         self.FR_pub.publish(FR_msg)
+
 
 if __name__ == "__main__":
 
     rospy.init_node('primitive_driver')
 
     # Grab params from launch file
-    thruster_BR_cog = rospy.get_param('~thruster_BR_cog')
     thruster_BL_cog = rospy.get_param('~thruster_BL_cog')
-    thruster_FR_cog = rospy.get_param('~thruster_FR_cog')
+    thruster_BR_cog = rospy.get_param('~thruster_BR_cog')
     thruster_FL_cog = rospy.get_param('~thruster_FL_cog')
-    thruster_BR_theta = rospy.get_param('~thruster_BR_theta')
-    thruster_BL_theta = rospy.get_param('~thruster_BL_theta')
-    thruster_FR_theta = rospy.get_param('~thruster_FR_theta')
-    thruster_FL_theta = rospy.get_param('~thruster_FL_theta')
+    thruster_FR_cog = rospy.get_param('~thruster_FR_cog')
+    thruster_BL_theta = np.deg2rad(rospy.get_param('~thruster_BL_theta'))
+    thruster_BR_theta = np.deg2rad(rospy.get_param('~thruster_BR_theta'))
+    thruster_FL_theta = np.deg2rad(rospy.get_param('~thruster_FL_theta'))
+    thruster_FR_theta = np.deg2rad(rospy.get_param('~thruster_FR_theta'))
+    effort_ratio = rospy.get_param('~effort_ratio')
+    effort_limit = rospy.get_param('~effort_limit')
 
     rate = rospy.Rate(50)
 
     # Create four thruster objects
-    BL = Thruster(thruster_BR_cog, thruster_BR_theta)
-    BR = Thruster(thruster_BL_cog, thruster_BL_theta)
-    FL = Thruster(thruster_FR_cog, thruster_FR_theta)
-    FR = Thruster(thruster_FL_cog, thruster_FL_theta)
-
-    # Set the thrust limit
-    thrust_limit = 600
+    BL = Thruster(thruster_BL_cog, thruster_BL_theta)
+    BR = Thruster(thruster_BR_cog, thruster_BR_theta)
+    FL = Thruster(thruster_FL_cog, thruster_FL_theta)
+    FR = Thruster(thruster_FR_cog, thruster_FR_theta)
 
     # Pass current thruster data and thrust limit to mapper
-    mapper = Mapper([BR.thruster_cog, BL.thruster_cog, FL.thruster_cog, FR.thruster_cog], thrust_limit)
+    mapper = Mapper([BL.cog, BR.cog, FL.cog, FR.cog], [BL.angle, BR.angle, FL.angle, FR.angle], effort_ratio, effort_limit)
 
     while not rospy.is_shutdown():
         # map thruster at 50hz
-        mapper.allocate([thruster_BR_theta, thruster_BL_theta, thruster_FL_theta, thruster_FR_theta])
+        mapper.allocate()
         rate.sleep()

--- a/mission_control/navigator_launch/launch/gnc.launch
+++ b/mission_control/navigator_launch/launch/gnc.launch
@@ -32,15 +32,16 @@
 
     <node pkg="navigator_thrust_mapper" type="thrust_mapper.py" name="thrust_mapper">
     <!-- Parameters used to set the thruster locations and angles relative to the center of gravity of the boat -->
-        <rosparam param="thruster_BR_cog">[-1.9304, 1.016]</rosparam>
-        <rosparam param="thruster_BL_cog">[-1.9304, -1.016]</rosparam>
-        <rosparam param="thruster_FR_cog">[1.5748, 0.6096]</rosparam>
-        <rosparam param="thruster_FL_cog">[1.5748, -0.6096]</rosparam>
-        <rosparam param="thruster_BR_theta">-45</rosparam>
+        <rosparam param="thruster_BL_cog">[-1.9304, 1.016]</rosparam>
+        <rosparam param="thruster_BR_cog">[-1.9304, -1.016]</rosparam>
+        <rosparam param="thruster_FL_cog">[1.5748, 0.6096]</rosparam>
+        <rosparam param="thruster_FR_cog">[1.5748, -0.6096]</rosparam>
         <rosparam param="thruster_BL_theta">45</rosparam>
-        <rosparam param="thruster_FR_theta">45</rosparam>
+        <rosparam param="thruster_BR_theta">-45</rosparam>
         <rosparam param="thruster_FL_theta">-45</rosparam>
-        <rosparam param="thrust_limit">-600</rosparam>
+        <rosparam param="thruster_FR_theta">45</rosparam>
+        <rosparam param="effort_ratio">2.7</rosparam><!-- map 220 newtons to 600 effort units -->
+        <rosparam param="effort_limit">600</rosparam>
     </node>
 
     <node name="wrench_arbiter" pkg="navigator_msg_multiplexer" type="wrench_arbiter.py"/>

--- a/mission_control/navigator_launch/launch/simulation.launch
+++ b/mission_control/navigator_launch/launch/simulation.launch
@@ -4,21 +4,22 @@
 -->
 
 <launch>
-	<node pkg="navigator_sim_model" type="sim.py" name="navigator_sim_model">
+	<node pkg="navigator_sim_model" type="sim.py" name="navigator_sim_model" output="screen">
 		<rosparam param="initial_position">[10, -5, 0]</rosparam>
-		<param name="boat_mass" value="36.2874" type="double"/>
-		<param name="boat_length" value="3.8608" type="double"/>
-		<param name="boat_width" value="2.4384" type="double"/>
-		<param name="boat_height" value="1.5" type="double"/>
-		<rosparam param="BR_offset">[-1.9304, 1.016]</rosparam>
-    	<rosparam param="BL_offset">[-1.9304, -1.016]</rosparam>
-    	<rosparam param="FR_offset">[1.5748, 0.6096]</rosparam>
-    	<rosparam param="FL_offset">[1.5748, -0.6096]</rosparam>
-		<param name="friction_coefficient_forward" value="100.0181" type="double"/>
+		<param name="boat_mass" value="300" type="double"/>
+		<param name="boat_length" value="4.85" type="double"/>
+		<param name="boat_width" value="1.2" type="double"/>
+		<param name="boat_height" value="0.8" type="double"/>
+    	<rosparam param="BL_offset">[-1.9304, 1.016]</rosparam>
+		<rosparam param="BR_offset">[-1.9304, -1.016]</rosparam>
+    	<rosparam param="FL_offset">[1.5748, 0.6096]</rosparam>
+    	<rosparam param="FR_offset">[1.5748, -0.6096]</rosparam>
+		<rosparam param="effort_ratio">2.7</rosparam>
+		<param name="friction_coefficient_forward" value="200" type="double"/>
 		<param name="friction_coefficient_forward_reduction" value="0.76462" type="double"/>
-		<param name="friction_coefficient_lateral" value="200.0" type="double"/>
+		<param name="friction_coefficient_lateral" value="300" type="double"/>
 		<param name="friction_coefficient_lateral_reduction" value="0.0" type="double"/>
-		<param name="friction_coefficient_rotational" value="100.3321" type="double"/>
+		<param name="friction_coefficient_rotational" value="300" type="double"/>
 		<param name="friction_coefficient_rotational_reduction" value="0.0" type="double"/>
 	</node>
 


### PR DESCRIPTION
There were a ton of places where mismatches in "which thrusters are where" (in a list of four of them) was causing chaos in the sim, and probably in real life. The unified standard is now:

BL, BR, FL, FR
(it's alphabetical, in case you forget)

I also fixed a bunch of other things:

- Thrust values in newtons were being sent straight to the thrusters. I multiplied in a conversion factor, which to my knowledge should map 220 N (measured max thrust) to 600 effort points (presumed max firmware value). This factor is a rosparam called effort_ratio.
- cos() and sin() of thruster angles in degrees were being taken, so I converted the angles to radians first.
- I replaced a manually implemented clip function with np.clip
- I deleted lines of code that did literally nothing
- The y-component of thrust directions was negated before the lever-arm cross-product was taken in the calculation of the B-matrix. Why? Probably fixed things in the past, but it was wrong fixing wrong. The problem was thruster ordering inconsistencies [BL, BR, FL, FR]. Now we have right fixing right.
- I updated the sim to have physical parameters that best match NaviGator (instead of PropaGator)

The sim is actually useful now, but it would be nice if it also visualized the desired waypoint simultaneously. I may do that another day.