### PR TITLE
SCRIPTING: Add networking scripts for easy networking setup

### DIFF
--- a/IPs.txt
+++ b/IPs.txt
@@ -1,0 +1,6 @@
+192.168.1.101 - wamv
+192.168.1.2 - wamv_onboard_router
+192.168.1.20 - wamv_onshore_router
+192.168.1.201 - wamv_lidar
+192.168.1.111 - Marth (Jason)
+192.168.1.112 - zach

--- a/net_setup.sh
+++ b/net_setup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Check for the proper argument - IP Address only for now
+if [ "$#" -ne 1 ]; then
+    echo "Please enter your NaviGator IP address as the first and only argument"
+    echo "FORMAT: 'bash net_setup.sh 192.168.X.XXX'"
+    echo "The assigned addresses can be found in the IPs.txt root directory of the NaviGator repository"
+    exit
+fi
+
+# Copy the .bashrc for replacment later
+cp ~/.bashrc ~/.temp_bashrc
+# Append the NaviGator computers ROS information
+echo "export ROS_MASTER_URI=http://wamv:11311" >> ~/.bashrc
+
+# Configure your ethernet port to the desired port
+sudo ifconfig eth0 $1
+
+# Copy the hosts file for replacement later
+sudo cp /etc/hosts /etc/temp_hosts
+
+# Add all the NaviGator host info to a temporary file in the current directory
+echo "127.0.0.1       localhost" > ./hosts
+echo "127.0.1.1       $HOSTNAME" >> ./hosts
+echo "192.168.1.101   wamv" >> ./hosts
+echo "192.168.1.2     wamv_onboard_router" >> ./hosts
+echo "192.168.1.20    wamv_onshore_router" >> ./hosts
+echo "192.168.1.201   wamv_lidar" >> ./hosts
+echo "192.168.1.111   Marth" >> ./hosts
+echo "192.168.1.112   zach" >> ./hosts
+echo "::1     ip6-localhost ip6-loopback" >> ./hosts
+echo "fe00::0 ip6-localnet" >> ./hosts
+echo "ff00::0 ip6-mcastprefix" >> ./hosts
+echo "ff02::1 ip6-allnodes" >> ./hosts
+echo "ff02::2 ip6-allrouters" >> ./hosts
+
+# Copy the temporary file to the /etc/hosts file
+sudo mv ./hosts /etc/hosts
+# Get back into user land
+sudo -k
+# source that junk
+source ~/.bashrc
+
+

--- a/restore_network.sh
+++ b/restore_network.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# remove altered .bashrc and move new one back
+rm ~/.bashrc
+cp ~/.temp_bashrc ~/.bashrc
+# flush ethernet changes
+sudo ifconfig eth0 0.0.0.0
+# remove altered hosts list and move new one back
+sudo mv /etc/temp_hosts /etc/hosts
+# back to user land
+sudo -k
+# source that junk
+source ~/.bashrc


### PR DESCRIPTION
These scripts are to speed up networking on the boat. The idea is to set up your laptop to work with the boat everytime you run "net_setup.sh" and remove any trace of networking with the boat when you run "restore_network.sh". You just give the IP you want to connect as and it will work. They will need to be updated as new people come on bu that is easy. I tested them by networking between my laptop and desktop as we would on the boat. 