### PR TITLE
Added navigator_msgs dependency to navigator_lidar

### DIFF
--- a/sensor_control/navigator_lidar/CMakeLists.txt
+++ b/sensor_control/navigator_lidar/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
 	pcl_ros
 	roscpp
 	sensor_msgs
+	navigator_msgs
 	)
 
 catkin_package(

--- a/sensor_control/navigator_lidar/package.xml
+++ b/sensor_control/navigator_lidar/package.xml
@@ -17,6 +17,7 @@
   <build_depend>roscpp</build_depend>
   <run_depend>message_runtime</run_depend>
   <build_depend>message_runtime</build_depend>
+  <build_depend>navigator_msgs</build_depend>
 
   <export>
   </export>


### PR DESCRIPTION
When building Navigator from a fresh install after following the wiki tutorial, I encountered this error:
`
/WORKSPACE/src/NaviGator/sensor_control/navigator_lidar/src/cluster_extraction.cpp:6:34: fatal error: navigator_msgs/Point.h: No such file or directory
 #include "navigator_msgs/Point.h"
                                  ^
compilation terminated.
` 

I don't really understand ROS or the whole build process of this project yet, but after some digging around on google I found that adding the project that generates Point.h to the find_package thing in the lidar cmake file made the build work. 