### PR TITLE
LIDAR: fix building with multiple threads

### DIFF
--- a/sensor_control/navigator_lidar/CMakeLists.txt
+++ b/sensor_control/navigator_lidar/CMakeLists.txt
@@ -24,6 +24,8 @@ include_directories(
 
 add_executable(cluster_extraction src/cluster_extraction.cpp)
 
+add_dependencies(cluster_extraction navigator_msgs_generate_messages)
+
 target_link_libraries(
 	cluster_extraction
  	${catkin_LIBRARIES}


### PR DESCRIPTION
Ensures navigator_msgs are generated before building lidar, even when building with several threads.

I thought I fixed this in fd3e7a3, but the issue still showed up when building with multiple threads, which is the default for catkin_make without specifying -j1.