### PR TITLE
Lidar: new readme with guide on how to use node

### DIFF
--- a/perception/navigator_lidar_oa/readme.md
+++ b/perception/navigator_lidar_oa/readme.md
@@ -1,0 +1,80 @@
+#Navigator Lidar Node - Ira Hill
+
+##Quick Overview
+
+**Required Interfaces**
+
+	- /velodyne_points
+	- /odom
+	- /get_bounds
+
+**Provided Interfaces**
+
+	- /ogrid
+	- /info_markers
+	- /database/objects
+	- /database/requests
+	- /unclassified_markers
+
+**Interfaces for Debugging**
+
+	- /ira_persist
+	- /ira_frame
+	- /ira_pclcloud
+  
+
+##Quick Start Guide
+
+**Starting the node**
+
+	- rosrun navigator_lidar_oa lidar
+
+**Requesting objects from the database**
+
+The service is name /database/requests with the input parameter name and will return the PerceptionObject message. Here are some example calls:
+
+
+	- rosservice call /database/requests "name: 'all'" 
+	- rosservice call /database/requests "name: 'shooter'"
+	- rosservice call /database/requests "name: 'totem'"
+	- rosservice call /database/requests "name: 'scan_the_code'"
+	- rosservice call /database/requests "name: 'start_gate'" 
+	- rosservice call /database/requests "name: 'buoy'"
+
+**Setting ROI objects from the database**
+
+ROI (region of interest) allows us to set fake markers in the database as estimates about where structures are located in the ENU world frame. This can either be done through rosservice with the cmd input or manually in RVIZ. The fake markers include: **BuoyField**, **CoralSurvey**, **FindBreak**, **AcousticPinger**, **Shooter**, **Scan\_The_Code**. (These can be changed/standardized later...). The syntax requires the name of the fake marker and the **x,y location in the ENU** frame after the = sign. Example calls:
+
+
+	- rosservice call /database/requests "cmd: 'Shooter=-27,-69'"
+	- rosservice call /database/requests "cmd: 'CoralSurvey=50.5,71.024'"
+
+**Interactive Markers in RVIZ**
+
+Subscribing to **/unclassified_markers** will allow RVIZ to setup interactive markers for objects found by the lidar. Right clicking on a marker will bring up the following menu:
+
+	- Type
+	- Lock
+	- Color
+
+Type allows you to change the object classification, lock will prevent the node from classifying this particular object in code, and color sets the rgb value of the object.
+Note that an unknown color defaults to 0,0,0 for rgb which is black, but we do have black buoys. So a black buoy is really 0.01,0.01,0.01 in rgb. (This can be addressed later!)
+
+The ROI fake markers will also show up in RVIZ at the origin. Simply drag these to the necessary locations.
+
+##Key parameters for the code
+These are the knobs to turn to control the behavior of the ogrid  (these will eventually become rosparams for easy editing). Most units are marked in the variable name but all variables use meters and degrees.
+
+	const double MAP_SIZE_METERS = 1500;
+	const double ROI_SIZE_METERS = 201;
+	const double VOXEL_SIZE_METERS = 0.30;
+	const int MIN_HITS_FOR_OCCUPANCY = 25; 
+	const int MAX_HITS_IN_CELL = 125; 
+	const double MAXIMUM_Z_BELOW_LIDAR = 2; 
+	const double MAXIMUM_Z_ABOVE_LIDAR = 2.5;
+	const double MAX_ROLL_PITCH_ANGLE_DEG = 5.3;
+	const double LIDAR_VIEW_ANGLE_DEG = 160;
+	const double LIDAR_VIEW_DISTANCE_METERS = 80;
+	const double LIDAR_MIN_VIEW_DISTANCE_METERS = 5.5;
+	const int MIN_LIDAR_POINTS_FOR_OCCUPANCY = 10;
+	const double MIN_OBJECT_HEIGHT_METERS = 0.075;

--- a/perception/navigator_lidar_oa/src/ConnectedComponents.h
+++ b/perception/navigator_lidar_oa/src/ConnectedComponents.h
@@ -202,7 +202,7 @@ std::vector< std::vector<int> > ConnectedComponents(OccupancyGrid &ogrid, std::v
 			obj.minHeightFromLidar = ii.second.minHeight;
 			obj.maxHeightFromLidar = ii.second.maxHeight;
 			//obj.color = ii.second.color; //Eventually work with color
-			if (obj.scale.z >= 0.2) {
+			if (obj.scale.z >= ogrid.objectMinHeight) {
 				objects.push_back(obj);
 			}
 			//ROS_INFO_STREAM(newId << " -> " << ob.position.x << "," << ob.position.y << "," << ob.position.z << "|" << ob.scale.x << "," << ob.scale.y << "," << ob.scale.z);

--- a/perception/navigator_lidar_oa/src/OccupancyGrid.h
+++ b/perception/navigator_lidar_oa/src/OccupancyGrid.h
@@ -122,11 +122,13 @@ class OccupancyGrid
 	    /// \param ?
 	    /// \param ?
 	    ////////////////////////////////////////////////////////////
-		void setLidarParams(const double LIDAR_VIEW_ANGLE_DEG, const double LIDAR_VIEW_DISTANCE_METERS, const double LIDAR_MIN_VIEW_DISTANCE)
+		void setLidarParams(const double LIDAR_VIEW_ANGLE_DEG, const double LIDAR_VIEW_DISTANCE_METERS, const double LIDAR_MIN_VIEW_DISTANCE, const int MIN_LIDAR_POINTS_FOR_OCCUPANCY, const double MIN_OBJECT_HEIGHT_METERS)
 		{
 			lidarViewAngle = LIDAR_VIEW_ANGLE_DEG;
 			lidarViewDistance = LIDAR_VIEW_DISTANCE_METERS;
-                        lidarMinViewDistance = LIDAR_MIN_VIEW_DISTANCE;
+            lidarMinViewDistance = LIDAR_MIN_VIEW_DISTANCE;
+            lidarMinPoints = MIN_LIDAR_POINTS_FOR_OCCUPANCY;
+            objectMinHeight = MIN_OBJECT_HEIGHT_METERS;
 		}
 
 
@@ -255,7 +257,7 @@ class OccupancyGrid
 				int binaryCol = 0;
 				for (int col = boatCol - ROI_SIZE/2; col < boatCol + ROI_SIZE/2; ++col,++binaryCol) {
 					//if ( std::abs(ogrid[row][col].max-ogrid[row][col].min) >= heightDiff && ogrid[row][col].hits >= minHit && ogrid[row][col].max <= maxHeight) { 
-					if ( ogrid[row][col].hits >= minHits && pointCloudTable[row*GRID_SIZE+col].q.size() >= 13 && ogrid[row][col].max-ogrid[row][col].min > 0.075) { 
+					if ( ogrid[row][col].hits >= minHits && pointCloudTable[row*GRID_SIZE+col].q.size() >= lidarMinPoints && ogrid[row][col].max-ogrid[row][col].min >= objectMinHeight) { 
 						//std::cout << "Found " << row << "," << col << " has " << pointCloudTable[row*GRID_SIZE+col].q.size() << " points" << std::endl;
 						//double r_enu = (row - GRID_SIZE/2)*VOXEL_SIZE_METERS,c_enu = (col - GRID_SIZE/2)*VOXEL_SIZE_METERS;
 						//std::cout << "Binary hit at x,y " << c_enu << "," << r_enu << "," << ogrid[row][col].hits << std::endl;
@@ -313,7 +315,8 @@ class OccupancyGrid
 		std::unordered_map<unsigned,beamEntry> pointCloudTable; ///< ???
 		std::unordered_map<unsigned,std::vector<LidarBeam>> pointCloudTable_Uno; ///< ???
 		Eigen::Vector2d b1,ab,ac;									///< ???
-		double lidarViewAngle,lidarViewDistance,lidarMinViewDistance;
+		double lidarViewAngle,lidarViewDistance,lidarMinViewDistance,objectMinHeight;
+		int lidarMinPoints;
 };	
 
 #endif

--- a/perception/navigator_lidar_oa/src/VolumeClassifier.h
+++ b/perception/navigator_lidar_oa/src/VolumeClassifier.h
@@ -12,9 +12,9 @@ void VolumeClassifier(objectMessage &object)
 		object.name = navigator_msgs::PerceptionObject::DETECT_DELIVER_PLATFORM;
 	} else if (object.maxHeightFromLidar >= 0.75 && object.scale.x > 2 && object.scale.y > 2 && object.scale.z > 1.25) {
 		object.name = navigator_msgs::PerceptionObject::SCAN_THE_CODE;
-	} else if (object.maxHeightFromLidar >= -0.25 && object.scale.x > 1.5 && object.scale.y > 1.5 && object.scale.z > 1.0) {
+	} else if (object.maxHeightFromLidar >= -0.25 && object.scale.x > 1.2 && object.scale.y > 1.2 && object.scale.z > 1.2) {
 		object.name = navigator_msgs::PerceptionObject::TOTEM;
-	} else if (object.maxHeightFromLidar < -0.25 && object.scale.x <= 1.5 && object.scale.y <= 1.5) {
+	} else if (object.maxHeightFromLidar < -0.25 && object.scale.x <= 1.2 && object.scale.y <= 1.2) {
 		object.name = navigator_msgs::PerceptionObject::BUOY;
 	} else {
 		object.name = navigator_msgs::PerceptionObject::UNKNOWN;

--- a/perception/navigator_lidar_oa/src/lidar.cpp
+++ b/perception/navigator_lidar_oa/src/lidar.cpp
@@ -50,6 +50,8 @@ const double MAX_ROLL_PITCH_ANGLE_DEG = 5.3;
 const double LIDAR_VIEW_ANGLE_DEG = 160;
 const double LIDAR_VIEW_DISTANCE_METERS = 80;
 const double LIDAR_MIN_VIEW_DISTANCE_METERS = 5.5;
+const int MIN_LIDAR_POINTS_FOR_OCCUPANCY = 10;
+const double MIN_OBJECT_HEIGHT_METERS = 0.075;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -151,7 +153,7 @@ void cb_velodyne(const sensor_msgs::PointCloud2ConstPtr &pcloud)
 
 	//Update occupancy grid
 	ogrid.setLidarPosition(lidarPos,lidarHeading);
-	ogrid.setLidarParams(LIDAR_VIEW_ANGLE_DEG,LIDAR_VIEW_DISTANCE_METERS,LIDAR_MIN_VIEW_DISTANCE_METERS);
+	ogrid.setLidarParams(LIDAR_VIEW_ANGLE_DEG,LIDAR_VIEW_DISTANCE_METERS,LIDAR_MIN_VIEW_DISTANCE_METERS,MIN_LIDAR_POINTS_FOR_OCCUPANCY,MIN_OBJECT_HEIGHT_METERS);
 	ogrid.updatePointsAsCloud(pcloud,T_enu_velodyne,MAX_HITS_IN_CELL,MAXIMUM_Z_BELOW_LIDAR,MAXIMUM_Z_ABOVE_LIDAR);
 	ogrid.createBinaryROI(MIN_HITS_FOR_OCCUPANCY);
 
@@ -335,7 +337,6 @@ void cb_velodyne(const sensor_msgs::PointCloud2ConstPtr &pcloud)
 				m2.color.a = 0.6; m2.color.r = 0.3; m2.color.g = 0.3; m2.color.b = 0.3;
 			} else {
 				m2.color.a = 0.6; m2.color.r = obj.color.r; m2.color.g = obj.color.g; m2.color.b = obj.color.b;
-				std::cout << m2.color.r << "," << m2.color.g << "," << m2.color.b << std::endl;
 			}
 			//markers.markers.push_back(m2);
 			int_marker.controls[0].markers.push_back( m2 );


### PR DESCRIPTION
Mostly cosmetic changes but wanted to get the readme in a PR for explanations of how to use the code. Here is a copy of the readme:

##Quick Overview

**Required Interfaces**

	- /velodyne_points
	- /odom
	- /get_bounds

**Provided Interfaces**

	- /ogrid
	- /info_markers
	- /database/objects
	- /database/requests
	- /unclassified_markers

**Interfaces for Debugging**

	- /ira_persist
	- /ira_frame
	- /ira_pclcloud
  

##Quick Start Guide

**Starting the node**

	- rosrun navigator_lidar_oa lidar

**Requesting objects from the database**

The service is name /database/requests with the input parameter name and will return the PerceptionObject message. Here are some example calls:


	- rosservice call /database/requests "name: 'all'" 
	- rosservice call /database/requests "name: 'shooter'"
	- rosservice call /database/requests "name: 'totem'"
	- rosservice call /database/requests "name: 'scan_the_code'"
	- rosservice call /database/requests "name: 'start_gate'" 
	- rosservice call /database/requests "name: 'buoy'"

**Setting ROI objects from the database**

ROI (region of interest) allows us to set fake markers in the database as estimates about where structures are located in the ENU world frame. This can either be done through rosservice with the cmd input or manually in RVIZ. The fake markers include: **BuoyField**, **CoralSurvey**, **FindBreak**, **AcousticPinger**, **Shooter**, **Scan\_The_Code**. (These can be changed/standardized later...). The syntax requires the name of the fake marker and the **x,y location in the ENU** frame after the = sign. Example calls:


	- rosservice call /database/requests "cmd: 'Shooter=-27,-69'"
	- rosservice call /database/requests "cmd: 'CoralSurvey=50.5,71.024'"

**Interactive Markers in RVIZ**

Subscribing to **/unclassified_markers** will allow RVIZ to setup interactive markers for objects found by the lidar. Right clicking on a marker will bring up the following menu:

	- Type
	- Lock
	- Color

Type allows you to change the object classification, lock will prevent the node from classifying this particular object in code, and color sets the rgb value of the object.
Note that an unknown color defaults to 0,0,0 for rgb which is black, but we do have black buoys. So a black buoy is really 0.01,0.01,0.01 in rgb. (This can be addressed later!)

The ROI fake markers will also show up in RVIZ at the origin. Simply drag these to the necessary locations.

##Key parameters for the code
These are the knobs to turn to control the behavior of the ogrid  (these will eventually become rosparams for easy editing). Most units are marked in the variable name but all variables use meters and degrees.

	const double MAP_SIZE_METERS = 1500;
	const double ROI_SIZE_METERS = 201;
	const double VOXEL_SIZE_METERS = 0.30;
	const int MIN_HITS_FOR_OCCUPANCY = 25; 
	const int MAX_HITS_IN_CELL = 125; 
	const double MAXIMUM_Z_BELOW_LIDAR = 2; 
	const double MAXIMUM_Z_ABOVE_LIDAR = 2.5;
	const double MAX_ROLL_PITCH_ANGLE_DEG = 5.3;
	const double LIDAR_VIEW_ANGLE_DEG = 160;
	const double LIDAR_VIEW_DISTANCE_METERS = 80;
	const double LIDAR_MIN_VIEW_DISTANCE_METERS = 5.5;
	const int MIN_LIDAR_POINTS_FOR_OCCUPANCY = 10;
	const double MIN_OBJECT_HEIGHT_METERS = 0.075;