### PR TITLE
OGRID, MISSIONS, TOOLS

### DIFF
--- a/gnc/navigator_msg_multiplexer/CMakeLists.txt
+++ b/gnc/navigator_msg_multiplexer/CMakeLists.txt
@@ -5,4 +5,10 @@ find_package(catkin REQUIRED COMPONENTS
 	rospy
 )
 
+#add dynamic reconfigure api
+find_package(catkin REQUIRED dynamic_reconfigure)
+generate_dynamic_reconfigure_options(
+  cfg/OgridConfig.cfg
+)
+
 catkin_package()

--- a/gnc/navigator_msg_multiplexer/cfg/OgridConfig.cfg
+++ b/gnc/navigator_msg_multiplexer/cfg/OgridConfig.cfg
@@ -10,5 +10,6 @@ gen.add("topics", str_t, 0, "A comma delimited list of ogrid topics to listen to
 gen.add("width", int_t, 0, "Width of output grid.", 1000, 0, 2000)
 gen.add("height", int_t, 0, "Height of output grid.", 1000, 0, 2000)
 gen.add("resolution", double_t, 0, "Resolution of output grid (not implemented)", 0.3, 0, 3)
+gen.add("ogrid_min_value", int_t, 0, "Minimum value to allow on the ogrid (can produce weird results)", -1, -100, 0)
 
 exit(gen.generate(PACKAGE, "navigator_msg_multiplexer", "Ogrid"))

--- a/gnc/navigator_msg_multiplexer/cfg/OgridConfig.cfg
+++ b/gnc/navigator_msg_multiplexer/cfg/OgridConfig.cfg
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+PACKAGE = "navigator_msg_multiplexer"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("topics", str_t, 0, "A comma delimited list of ogrid topics to listen to.", "ogrid")
+
+gen.add("width", int_t, 0, "Width of output grid.", 1000, 0, 2000)
+gen.add("height", int_t, 0, "Height of output grid.", 1000, 0, 2000)
+gen.add("resolution", double_t, 0, "Resolution of output grid (not implemented)", 0.3, 0, 3)
+
+exit(gen.generate(PACKAGE, "navigator_msg_multiplexer", "Ogrid"))

--- a/gnc/navigator_msg_multiplexer/launch/ogrid_server.launch
+++ b/gnc/navigator_msg_multiplexer/launch/ogrid_server.launch
@@ -1,0 +1,4 @@
+<launch>
+  <node name="ogrid_server" pkg="navigator_lidar_oa" type="ogrid_server.py" output="screen"
+  args="--topics /ogrid /ogrid_batcave" />
+</launch>

--- a/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
+++ b/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
@@ -1,12 +1,18 @@
 #!/usr/bin/python
+from __future__ import division
+
 import tf
 import rospy
 import roslib
-import argparse
-import numpy as np
 import navigator_tools
-import message_filters
-import matplotlib.image as mpimg
+from navigator_tools import fprint as _fprint
+
+from scipy.misc import imresize
+import numpy as np
+from copy import deepcopy
+
+from dynamic_reconfigure.server import Server
+from navigator_msg_multiplexer.cfg import OgridConfig
 
 from rostopic import ROSTopicHz
 from nav_msgs.msg import OccupancyGrid, MapMetaData
@@ -23,6 +29,58 @@ from nav_msgs.msg import OccupancyGrid, MapMetaData
 ''          - Service call to /_____/____ will trigger an update
 '''
 
+# Wow what a concept
+fprint = lambda *args, **kwargs: _fprint(title="OGRID_ARB", *args, **kwargs)
+
+def make_ogrid_transform(ogrid):
+        '''
+            Returns a matrix that transforms a point in ENU to this ogrid.
+            Invert the result to get ogrid -> ENU.
+        '''
+        resolution = ogrid.info.resolution
+        origin = navigator_tools.pose_to_numpy(ogrid.info.origin)[0]
+
+        # Transforms points from ENU to ogrid frame coordinates
+        t = np.array([[1 / resolution,  0, -origin[1] / resolution],
+                      [0,  1 / resolution, -origin[0] / resolution],
+                      [0,               0,                       1]])
+        return t
+
+def numpyify(ogrid):
+    # Could be a lambda
+    return np.array(ogrid.data).reshape(ogrid.info.height, ogrid.info.width)
+
+def transform_enu_to_ogrid(enu_points, grid):
+    '''
+        Convert an enu point into the global ogrid's frame.
+        `enu_points` should be a list of points in the ENU frame that will be converted
+            into the grid frame
+    '''
+    t = make_ogrid_transform(grid)
+    return t.dot(np.array(enu_points).T).T
+
+def transform_ogrid_to_enu(grid_points, grid):
+    '''
+        Convert an ogrid cell into the enu frame.
+        `grid_points` should be a list of points in the ogrid frame that will be converted
+            into the ENU frame
+    '''
+    t = np.linalg.inv(make_ogrid_transform(grid))
+    return t.dot(np.array(grid_points).T).T
+
+def transform_between_ogrids(grid1_points, grid1, grid2):
+    enu = transform_ogrid_to_enu(grid1_points, grid1)
+    return transform_enu_to_ogrid(enu, grid2)
+
+def get_enu_corners(grid):
+    '''
+        Given an ogrid, this returns the top left (?) and bottom right (?) points in the ENU frame
+    '''
+    grid_to_enu = np.linalg.inv(make_ogrid_transform(grid))
+    _min = grid_to_enu.dot([0, 0, 1])
+    _max = grid_to_enu.dot([grid.info.height, grid.info.width, 1])
+    return (_min, _max)
+
 class OGrid:
     def __init__(self, topic, frame_id='enu', debug=False):
         # Assert that the topic is valid
@@ -37,42 +95,51 @@ class OGrid:
         self.np_map = None              # Numpy version of last recieved OccupancyGrid message
         self.debug = debug              # Diagnostic print flag
 
-        self.subscriber = rospy.Subscriber(self.topic, OccupancyGrid, self.cb, queue_size=1)
+        self.transform = None
 
-    def __repr__(self):
-        #return '<%s instance at %s>' % (self.__class__.__name__, if self)
-        pass
+        self.subscriber = rospy.Subscriber(self.topic, OccupancyGrid, self.cb, queue_size=1)
 
     def __str__(self):
         # TODO: Reformat this line
-        return '{}: \nFrame ID: {}\n  Position: {}\n  Last Message Recieved: {}\n  Status: {}\n'.format(self.topic,
-                                                                                                   self.map_position,
-                                                                                                   self.last_message_stamp,
-                                                                                                   self.status)
+        return '{}: \nFrame ID: {}\n  Position: {}\n  Callback Delta: {}\n'.format(self.topic,
+                                                                                   self.frame_id,
+                                                                                   self.map_position,
+                                                                                   self.callback_delta)
+
+    @property
+    def callback_delta(self):
+        if self.last_message_stamp is None:
+            return 0
+        return (rospy.Time.now() - self.last_message_stamp).to_sec()
+
+    def trim_to_global(self, g_xs, g_ys, global_ogrid):
+        start_x, end_x = transform_between_ogrids(g_xs, global_ogrid, self.nav_ogrid)[:2]
+        start_y, end_y = transform_between_ogrids(g_ys, global_ogrid, self.nav_ogrid)[:2]
+        return self.np_map[start_x:end_x, start_y:end_y]
+
+    def get_enu_corners(self):
+        if self.nav_ogrid is None:
+            return None
+        return get_enu_corners(self.nav_ogrid)
 
     def convert_ogrid_np(self):
         # Converts nav_msgs/OccupancyGrid to Numpy array
         if self.nav_ogrid is None:
-            # raise ValueError('No OccupancyMap stored by %i', id(self))
-            pass
-        else:
-            grid_ = np.asarray(self.nav_ogrid.data).reshape(self.nav_ogrid.info.width, self.nav_ogrid.info.height)
-        return grid_
+            return None
 
-    def interpolate_ogrid(self, ogrid_, scale):
-        # Handling maps with different scales (???)
-        pass
+        # Reject 2 second old ogrids
+        if self.callback_delta > 2:
+            return None
 
-    def callback_delta(self):
-        return rospy.get_rostime() - self.last_message_stamp
+        return numpyify(self.nav_ogrid)
 
     def cb(self, ogrid):
         # Fetches the currently available map
         self.last_message_stamp = ogrid.header.stamp
         self.nav_ogrid = ogrid
-        self.np_map = self.convert_ogrid_np(ogird)
+        self.np_map = self.convert_ogrid_np()
 
-        if self.debug is False:
+        if self.debug:
             # TODO: Why is this not printing?
             rospy.loginfo('  Topic: %s', self.topic)
             rospy.loginfo('  Last recieved stamp: %s', str(self.last_message_stamp.secs))
@@ -80,88 +147,135 @@ class OGrid:
 
 
 class OGridServer:
-    def __init__(self, topics=None, frame_id='enu', map_size=200, resolution=0.3, rate=30):
-
-        rospy.init_node('ogrid_server', anonymous=False)
-
+    def __init__(self, topics=None, frame_id='enu', map_size=800, resolution=0.3, rate=1):
         self.resolution = resolution        # Meter/Grid Space
-        self.size = (map_size, map_size)    # Size of the grid on which we will place incoming grids
+        self.size = (map_size, map_size)    # Size of the grid on which we will place incoming grids (meters)
 
         self.topics = topics                # List of nav_msgs/topics that we wish to subscribe to
-        self.rate = rospy.Rate(int(rate))   # Rate at which we will publish the merge ogrid
         self.frame_id = frame_id            # Frame that we will be operating from (ENU)
-        self.ogrids = []                    # List of maps that have been added to the global map (In case we want to remove maps)
+        self.ogrids = {}                    # Dict of maps that have been added to the global map (In case we want to remove maps)
 
-        # Spool up a Map object for every ogrid that we wish to work with
-        self.ogrids = [OGrid(frame_id='enu', topic=topic) for topic in topics]
+        self.global_ogrid = self.create_grid(self.size, self.resolution)
 
-        self.publisher = rospy.Publisher('/ogrid_server/global_grid', OccupancyGrid, queue_size=1)
+        self.publisher = rospy.Publisher('/ogrid_master', OccupancyGrid, queue_size=1)
 
-        # Diagnostic Information
-        rospy.loginfo('Occupancy Map Server Initialized')
-        rospy.loginfo('Adding %i maps to server', len(self.topics))
+        srv = Server(OgridConfig, self.dynamic_cb)
 
-        rospy.Timer(rospy.Duration(0.1), self.cb())
+        rospy.Timer(rospy.Duration(1.0 / rate), self.publish)
 
-    def __repr__(self):
-        return 'Work in progress'
+        rospy.spin()
 
-    def create_grid(self, map_size, resolution=self.):
+    def dynamic_cb(self, config, level):
+        topics =  config['topics'].replace(' ', '').split(',')
+        new_grids = {}
+
+        for topic in topics:
+           new_grids[topic] = OGrid(topic) if topic not in self.ogrids else self.ogrids[topic]
+
+        self.ogrids = new_grids
+
+        # Change size or resolution of global ogrid
+        return config
+
+    def create_grid(self, map_size, resolution, origin=None):
+        '''
+            Creates blank ogrids for everyone for the low low price of $9.95!
+            `map_size` should be in the form of (h, w)
+            `resolution` should be in m/cell
+        '''
         ogrid_ = OccupancyGrid()
         ogrid_.header.stamp = rospy.Time.now()
         ogrid_.header.frame_id = self.frame_id
 
-        # TODO: Map position!!!!
         ogrid_.info.resolution = resolution
-        ogrid_.info.width = map_size
-        ogrid_.info.height = map_size
+        ogrid_.info.width = map_size[1]
+        ogrid_.info.height = map_size[0]
 
-        rospy.loginfo('Created Occupancy Map')
+        if origin is None:
+            position = np.array([-(map_size[1] * resolution) / 2, -(map_size[0] * resolution) / 2, 0])
+            quaternion = np.array([0, 0, 0, 1])
+            origin = navigator_tools.numpy_quat_pair_to_pose(position, quaternion)
+
+        ogrid_.info.origin = origin
+
+        # TODO: Make sure this produces the correct sized ogrid
+        ogrid_.data = np.full((map_size[1], map_size[0]), -1).flatten()
+
+        fprint('Created Occupancy Map')
         return ogrid_
-
-    def transform_ogrid(self, ogrid):
-        # If the occupancy map's frame id is not the default, transform it
-        pass
 
     def merge_grids(self):
-        rospy.loginfo('Merging Maps')
-        ogrid_ = OccupancyGrid()
-        ogrid_.header = navigator_tools.make_header(frame=self.frame_id)
+        #rospy.loginfo('Merging Maps')
+        global_ogrid = deepcopy(self.global_ogrid)
 
-        # TODO: Move these operations elsewhere, they seem to be slowing everything down
-        global_ogrid_ = np.full((671, 671), -1)
+        np_grid = numpyify(global_ogrid)
 
-        m_ = MapMetaData()
-        m_.resolution = 0.3
-        m_.width = 671
-        m_.height = 671
+        for ogrid in self.ogrids.itervalues():
+            if ogrid.nav_ogrid is None or ogrid.callback_delta > 2:
+                continue
 
-        position = np.array([-67.5, -111.5, 1.6])
-        quaternion = np.array([0, 0, 0, 1])
+            # Global ogrid
+            corners = get_enu_corners(global_ogrid)
+            index_limits = transform_enu_to_ogrid(corners, global_ogrid)[:,:2]
 
-        m_.origin = navigator_tools.numpy_quat_pair_to_pose(position, quaternion)
+            g_x_min = index_limits[0][0]
+            g_x_max = index_limits[1][0]
 
-        for ogrid in self.ogrids:
-            if ogrid.nav_ogrid is None:
-                pass
-            else:
-                o_np = ogrid.convert_ogrid_np()                   # Numpy representation of occupancy grid
-                np.add(global_ogrid_, o_np, out=global_ogrid_)    # Add current ogrid to global one
+            g_y_min = index_limits[0][1]
+            g_y_max = index_limits[1][1]
 
-        np.clip(global_ogrid_, -1, 99, out=global_ogrid_)         # Clip values for OccupancyGrid bounds
+            # Local Ogrid (get everything in global frame though)
+            corners = ogrid.get_enu_corners()
+            index_limits = transform_enu_to_ogrid(corners, ogrid.nav_ogrid)
+            index_limits = transform_between_ogrids(index_limits, ogrid.nav_ogrid, global_ogrid)[:,:2]
 
-        ogrid_.info = m_
-        ogrid_.data = global_ogrid_.flatten()
+            l_x_min = index_limits[0][0]
+            l_x_max = index_limits[1][0]
 
-        return ogrid_
+            l_y_min = index_limits[0][1]
+            l_y_max = index_limits[1][1]
+
+            xs = np.sort([g_x_max, g_x_min, l_x_max, l_x_min])
+            ys = np.sort([g_y_max, g_y_min, l_y_max, l_y_min])
+
+            start_x = xs[1]
+            end_x = xs[2]
+
+            start_y = ys[1]
+            end_y = ys[2]
+
+            fprint("{},{} {},{}".format(start_x, start_y, end_x, end_y))
+
+            # Assuming resolution has been normalized.
+            # Getting the indices to slice the local ogrid.
+            l_ogrid_start = transform_between_ogrids([start_x, start_y, 1], global_ogrid, ogrid.nav_ogrid)
+            index_width = round(l_ogrid_start[0] + end_x - start_x)  # I suspect rounding will be the source of error
+            index_height = round(l_ogrid_start[1] + end_y - start_y)
+
+            try:
+                to_add = ogrid.np_map[l_ogrid_start[0]:index_width, l_ogrid_start[1]:index_height]
+                fprint("to_add shape: {}".format(to_add.shape))
+                np_grid[start_x:end_x, start_y:end_y] += to_add
+                fprint("np_grid shape: {}".format(np_grid[start_x:end_x, start_y:end_y].shape))
+            except Exception as e:
+                fprint("Exception caught, probably a dimension mismatch:", msg_color='red')
+                print e
+
+            print "=" * 25
+
+
+
+        np_grid = np.clip(np_grid, -1, 100)         # Clip values for OccupancyGrid bounds
+        global_ogrid.data = np_grid.flatten().astype(np.int8)
+
+        print "=" * 50
+        return global_ogrid
 
     def check_ogrid_topics():
         pass
 
-    def cb(self):
+    def publish(self, *args):
         self.publisher.publish(self.merge_grids())
-        self.rate.sleep()
-        rospy.spin()
 
     # TODO: Make these service calls
     def add_grid(self, ogrid, interpolate=False):
@@ -180,14 +294,12 @@ class OGridServer:
         pass
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--topics', '-t', nargs = '*', help='Provide topics that the server will subscribe to')
-    args = parser.parse_args()
-
     #if args.topics is None:
     #    rospy.logwarn('No input topics provided')
         # Trigger search for nav_msgs/OccupancyGrid topics currently being published. If there are
         # none, then exit with logerr.
     #    pass
     #elif args.topics is not None:
-    og_server = OGridServer(topics=['/ogrid', '/ogrid_batcave'])
+
+    rospy.init_node('ogrid_server', anonymous=False)
+    og_server = OGridServer()

--- a/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
+++ b/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
@@ -115,6 +115,8 @@ class OGridServer:
         self.frame_id = frame_id            # Frame that we will be operating from (ENU)
         self.ogrids = {}                    # Dict of maps that have been added to the global map (In case we want to remove maps)
 
+        self.ogrid_min_value = -1
+
         self.global_ogrid = self.create_grid((map_size, map_size), resolution)
 
         self.publisher = rospy.Publisher('/ogrid_master', OccupancyGrid, queue_size=1)
@@ -139,6 +141,8 @@ class OGridServer:
 
         map_size = map(int, (config['height'], config['width']))
         self.global_ogrid = self.create_grid(map_size, float(config['resolution']))
+
+        self.ogrid_min_value = config['ogrid_min_value']
 
         # Change size or resolution of global ogrid
         return config
@@ -229,7 +233,7 @@ class OGridServer:
 
             print "{}>".format("=" * 25)
 
-        np_grid = np.clip(np_grid, -1, 100)         # Clip values for OccupancyGrid bounds
+        np_grid = np.clip(np_grid, self.ogrid_min_value, 100)         # Clip values for OccupancyGrid bounds
         global_ogrid.data = np_grid.flatten().astype(np.int8)
 
         print "\n{}>".format("=" * 50)

--- a/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
+++ b/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
@@ -194,6 +194,8 @@ class OGridServer:
         for ogrid in self.ogrids.itervalues():
             # Hard coded 2 second timeout - probably no need to reconfig this.
             if ogrid.nav_ogrid is None or ogrid.callback_delta > 2:
+                fprint("Ogrid too old!")
+                print "{}>".format("=" * 25)
                 continue
 
             # Local Ogrid (get everything in global frame though)

--- a/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
+++ b/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
@@ -1,0 +1,193 @@
+#!/usr/bin/python
+import tf
+import rospy
+import roslib
+import argparse
+import numpy as np
+import navigator_tools
+import message_filters
+import matplotlib.image as mpimg
+
+from rostopic import ROSTopicHz
+from nav_msgs.msg import OccupancyGrid, MapMetaData
+
+'''
+''  - NaviGator Occupancy Grid Server -
+''      Server that will handle merging multiple ROS Occupancy Maps into one map which
+''      will then be fed to the motion planner.
+''
+''      Requirements:
+''      1. At launch, all nodes specified in launch file will be merged onto the global map.
+''      2. New maps can be added to the server via. the Parameter Server. This is outlined below:
+''          - Added via paramter server
+''          - Service call to /_____/____ will trigger an update
+'''
+
+class OGrid:
+    def __init__(self, topic, frame_id='enu', debug=False):
+        # Assert that the topic is valid
+        self.topic = topic
+        self.frame_id = frame_id
+
+        self.last_message_stamp = None
+        self.map_position = None        # We should default to the origin if no map location is given
+
+        self.status = False             # If we are no  longer using this map, status is False
+        self.nav_ogrid = None           # Last recieved OccupancyGrid message
+        self.np_map = None              # Numpy version of last recieved OccupancyGrid message
+        self.debug = debug              # Diagnostic print flag
+
+        self.subscriber = rospy.Subscriber(self.topic, OccupancyGrid, self.cb, queue_size=1)
+
+    def __repr__(self):
+        #return '<%s instance at %s>' % (self.__class__.__name__, if self)
+        pass
+
+    def __str__(self):
+        # TODO: Reformat this line
+        return '{}: \nFrame ID: {}\n  Position: {}\n  Last Message Recieved: {}\n  Status: {}\n'.format(self.topic,
+                                                                                                   self.map_position,
+                                                                                                   self.last_message_stamp,
+                                                                                                   self.status)
+
+    def convert_ogrid_np(self):
+        # Converts nav_msgs/OccupancyGrid to Numpy array
+        if self.nav_ogrid is None:
+            # raise ValueError('No OccupancyMap stored by %i', id(self))
+            pass
+        else:
+            grid_ = np.asarray(self.nav_ogrid.data).reshape(self.nav_ogrid.info.width, self.nav_ogrid.info.height)
+        return grid_
+
+    def interpolate_ogrid(self, ogrid_, scale):
+        # Handling maps with different scales (???)
+        pass
+
+    def callback_delta(self):
+        return rospy.get_rostime() - self.last_message_stamp
+
+    def cb(self, ogrid):
+        # Fetches the currently available map
+        self.last_message_stamp = ogrid.header.stamp
+        self.nav_ogrid = ogrid
+        self.np_map = self.convert_ogrid_np(ogird)
+
+        if self.debug is False:
+            # TODO: Why is this not printing?
+            rospy.loginfo('  Topic: %s', self.topic)
+            rospy.loginfo('  Last recieved stamp: %s', str(self.last_message_stamp.secs))
+            rospy.loginfo('  Callback Delta: %s', str(self.callback_delta))
+
+
+class OGridServer:
+    def __init__(self, topics=None, frame_id='enu', map_size=200, resolution=0.3, rate=30):
+
+        rospy.init_node('ogrid_server', anonymous=False)
+
+        self.resolution = resolution        # Meter/Grid Space
+        self.size = (map_size, map_size)    # Size of the grid on which we will place incoming grids
+
+        self.topics = topics                # List of nav_msgs/topics that we wish to subscribe to
+        self.rate = rospy.Rate(int(rate))   # Rate at which we will publish the merge ogrid
+        self.frame_id = frame_id            # Frame that we will be operating from (ENU)
+        self.ogrids = []                    # List of maps that have been added to the global map (In case we want to remove maps)
+
+        # Spool up a Map object for every ogrid that we wish to work with
+        self.ogrids = [OGrid(frame_id='enu', topic=topic) for topic in topics]
+
+        self.publisher = rospy.Publisher('/ogrid_server/global_grid', OccupancyGrid, queue_size=1)
+
+        # Diagnostic Information
+        rospy.loginfo('Occupancy Map Server Initialized')
+        rospy.loginfo('Adding %i maps to server', len(self.topics))
+
+        rospy.Timer(rospy.Duration(0.1), self.cb())
+
+    def __repr__(self):
+        return 'Work in progress'
+
+    def create_grid(self, map_size, resolution=self.):
+        ogrid_ = OccupancyGrid()
+        ogrid_.header.stamp = rospy.Time.now()
+        ogrid_.header.frame_id = self.frame_id
+
+        # TODO: Map position!!!!
+        ogrid_.info.resolution = resolution
+        ogrid_.info.width = map_size
+        ogrid_.info.height = map_size
+
+        rospy.loginfo('Created Occupancy Map')
+        return ogrid_
+
+    def transform_ogrid(self, ogrid):
+        # If the occupancy map's frame id is not the default, transform it
+        pass
+
+    def merge_grids(self):
+        rospy.loginfo('Merging Maps')
+        ogrid_ = OccupancyGrid()
+        ogrid_.header = navigator_tools.make_header(frame=self.frame_id)
+
+        # TODO: Move these operations elsewhere, they seem to be slowing everything down
+        global_ogrid_ = np.full((671, 671), -1)
+
+        m_ = MapMetaData()
+        m_.resolution = 0.3
+        m_.width = 671
+        m_.height = 671
+
+        position = np.array([-67.5, -111.5, 1.6])
+        quaternion = np.array([0, 0, 0, 1])
+
+        m_.origin = navigator_tools.numpy_quat_pair_to_pose(position, quaternion)
+
+        for ogrid in self.ogrids:
+            if ogrid.nav_ogrid is None:
+                pass
+            else:
+                o_np = ogrid.convert_ogrid_np()                   # Numpy representation of occupancy grid
+                np.add(global_ogrid_, o_np, out=global_ogrid_)    # Add current ogrid to global one
+
+        np.clip(global_ogrid_, -1, 99, out=global_ogrid_)         # Clip values for OccupancyGrid bounds
+
+        ogrid_.info = m_
+        ogrid_.data = global_ogrid_.flatten()
+
+        return ogrid_
+
+    def check_ogrid_topics():
+        pass
+
+    def cb(self):
+        self.publisher.publish(self.merge_grids())
+        self.rate.sleep()
+        rospy.spin()
+
+    # TODO: Make these service calls
+    def add_grid(self, ogrid, interpolate=False):
+        pass
+
+    def pause_grid(self):
+        pass
+
+    def remove_grid(self):
+        pass
+
+    def update_global_map(self):
+        pass
+
+    def reset_global_grid(self):
+        pass
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--topics', '-t', nargs = '*', help='Provide topics that the server will subscribe to')
+    args = parser.parse_args()
+
+    #if args.topics is None:
+    #    rospy.logwarn('No input topics provided')
+        # Trigger search for nav_msgs/OccupancyGrid topics currently being published. If there are
+        # none, then exit with logerr.
+    #    pass
+    #elif args.topics is not None:
+    og_server = OGridServer(topics=['/ogrid', '/ogrid_batcave'])

--- a/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
+++ b/gnc/navigator_msg_multiplexer/nodes/ogrid_arbiter.py
@@ -32,6 +32,7 @@ from nav_msgs.msg import OccupancyGrid, MapMetaData
 # Wow what a concept
 fprint = lambda *args, **kwargs: _fprint(title="OGRID_ARB", *args, **kwargs)
 
+
 def make_ogrid_transform(ogrid):
         '''
             Returns a matrix that transforms a point in ENU to this ogrid.
@@ -46,9 +47,11 @@ def make_ogrid_transform(ogrid):
                       [0,               0,                       1]])
         return t
 
+
 def numpyify(ogrid):
     # Could be a lambda
     return np.array(ogrid.data).reshape(ogrid.info.height, ogrid.info.width)
+
 
 def transform_enu_to_ogrid(enu_points, grid):
     '''
@@ -59,6 +62,7 @@ def transform_enu_to_ogrid(enu_points, grid):
     t = make_ogrid_transform(grid)
     return t.dot(np.array(enu_points).T).T
 
+
 def transform_ogrid_to_enu(grid_points, grid):
     '''
         Convert an ogrid cell into the enu frame.
@@ -68,9 +72,11 @@ def transform_ogrid_to_enu(grid_points, grid):
     t = np.linalg.inv(make_ogrid_transform(grid))
     return t.dot(np.array(grid_points).T).T
 
+
 def transform_between_ogrids(grid1_points, grid1, grid2):
     enu = transform_ogrid_to_enu(grid1_points, grid1)
     return transform_enu_to_ogrid(enu, grid2)
+
 
 def get_enu_corners(grid):
     '''
@@ -81,30 +87,16 @@ def get_enu_corners(grid):
     _max = grid_to_enu.dot([grid.info.height, grid.info.width, 1])
     return (_min, _max)
 
+
 class OGrid:
-    def __init__(self, topic, frame_id='enu', debug=False):
+    def __init__(self, topic, frame_id='enu'):
         # Assert that the topic is valid
-        self.topic = topic
-        self.frame_id = frame_id
-
         self.last_message_stamp = None
-        self.map_position = None        # We should default to the origin if no map location is given
 
-        self.status = False             # If we are no  longer using this map, status is False
         self.nav_ogrid = None           # Last recieved OccupancyGrid message
         self.np_map = None              # Numpy version of last recieved OccupancyGrid message
-        self.debug = debug              # Diagnostic print flag
 
-        self.transform = None
-
-        self.subscriber = rospy.Subscriber(self.topic, OccupancyGrid, self.cb, queue_size=1)
-
-    def __str__(self):
-        # TODO: Reformat this line
-        return '{}: \nFrame ID: {}\n  Position: {}\n  Callback Delta: {}\n'.format(self.topic,
-                                                                                   self.frame_id,
-                                                                                   self.map_position,
-                                                                                   self.callback_delta)
+        self.subscriber = rospy.Subscriber(topic, OccupancyGrid, self.cb, queue_size=1)
 
     @property
     def callback_delta(self):
@@ -112,67 +104,41 @@ class OGrid:
             return 0
         return (rospy.Time.now() - self.last_message_stamp).to_sec()
 
-    def trim_to_global(self, g_xs, g_ys, global_ogrid):
-        start_x, end_x = transform_between_ogrids(g_xs, global_ogrid, self.nav_ogrid)[:2]
-        start_y, end_y = transform_between_ogrids(g_ys, global_ogrid, self.nav_ogrid)[:2]
-        return self.np_map[start_x:end_x, start_y:end_y]
-
-    def get_enu_corners(self):
-        if self.nav_ogrid is None:
-            return None
-        return get_enu_corners(self.nav_ogrid)
-
-    def convert_ogrid_np(self):
-        # Converts nav_msgs/OccupancyGrid to Numpy array
-        if self.nav_ogrid is None:
-            return None
-
-        # Reject 2 second old ogrids
-        if self.callback_delta > 2:
-            return None
-
-        return numpyify(self.nav_ogrid)
-
     def cb(self, ogrid):
         # Fetches the currently available map
         self.last_message_stamp = ogrid.header.stamp
         self.nav_ogrid = ogrid
-        self.np_map = self.convert_ogrid_np()
-
-        if self.debug:
-            # TODO: Why is this not printing?
-            rospy.loginfo('  Topic: %s', self.topic)
-            rospy.loginfo('  Last recieved stamp: %s', str(self.last_message_stamp.secs))
-            rospy.loginfo('  Callback Delta: %s', str(self.callback_delta))
-
+        self.np_map = numpyify(ogrid)
 
 class OGridServer:
-    def __init__(self, topics=None, frame_id='enu', map_size=800, resolution=0.3, rate=1):
-        self.resolution = resolution        # Meter/Grid Space
-        self.size = (map_size, map_size)    # Size of the grid on which we will place incoming grids (meters)
-
-        self.topics = topics                # List of nav_msgs/topics that we wish to subscribe to
+    def __init__(self, frame_id='enu', map_size=800, resolution=0.3, rate=2):
         self.frame_id = frame_id            # Frame that we will be operating from (ENU)
         self.ogrids = {}                    # Dict of maps that have been added to the global map (In case we want to remove maps)
 
-        self.global_ogrid = self.create_grid(self.size, self.resolution)
+        self.global_ogrid = self.create_grid((map_size, map_size), resolution)
 
         self.publisher = rospy.Publisher('/ogrid_master', OccupancyGrid, queue_size=1)
 
-        srv = Server(OgridConfig, self.dynamic_cb)
+        Server(OgridConfig, self.dynamic_cb)
 
         rospy.Timer(rospy.Duration(1.0 / rate), self.publish)
-
         rospy.spin()
 
     def dynamic_cb(self, config, level):
-        topics =  config['topics'].replace(' ', '').split(',')
+        '''
+            Deal with a dynamic reconfigure update
+        '''
+        fprint("DYNAMIC CONFIG UPDATE!", newline=3, msg_color='blue')
+        topics = config['topics'].replace(' ', '').split(',')
         new_grids = {}
 
         for topic in topics:
            new_grids[topic] = OGrid(topic) if topic not in self.ogrids else self.ogrids[topic]
 
         self.ogrids = new_grids
+
+        map_size = map(int, (config['height'], config['width']))
+        self.global_ogrid = self.create_grid(map_size, float(config['resolution']))
 
         # Change size or resolution of global ogrid
         return config
@@ -201,31 +167,33 @@ class OGridServer:
         # TODO: Make sure this produces the correct sized ogrid
         ogrid_.data = np.full((map_size[1], map_size[0]), -1).flatten()
 
-        fprint('Created Occupancy Map')
+        fprint('Created Occupancy Map', msg_color='blue')
         return ogrid_
 
     def merge_grids(self):
-        #rospy.loginfo('Merging Maps')
+        fprint("Merging Maps", newline=2)
         global_ogrid = deepcopy(self.global_ogrid)
-
         np_grid = numpyify(global_ogrid)
 
+        print "{}>".format("=" * 25)
+
+        # Global ogrid (only compute once)
+        corners = get_enu_corners(global_ogrid)
+        index_limits = transform_enu_to_ogrid(corners, global_ogrid)[:,:2]
+
+        g_x_min = index_limits[0][0]
+        g_x_max = index_limits[1][0]
+
+        g_y_min = index_limits[0][1]
+        g_y_max = index_limits[1][1]
+
         for ogrid in self.ogrids.itervalues():
+            # Hard coded 2 second timeout - probably no need to reconfig this.
             if ogrid.nav_ogrid is None or ogrid.callback_delta > 2:
                 continue
 
-            # Global ogrid
-            corners = get_enu_corners(global_ogrid)
-            index_limits = transform_enu_to_ogrid(corners, global_ogrid)[:,:2]
-
-            g_x_min = index_limits[0][0]
-            g_x_max = index_limits[1][0]
-
-            g_y_min = index_limits[0][1]
-            g_y_max = index_limits[1][1]
-
             # Local Ogrid (get everything in global frame though)
-            corners = ogrid.get_enu_corners()
+            corners = get_enu_corners(ogrid.nav_ogrid)
             index_limits = transform_enu_to_ogrid(corners, ogrid.nav_ogrid)
             index_limits = transform_between_ogrids(index_limits, ogrid.nav_ogrid, global_ogrid)[:,:2]
 
@@ -238,18 +206,15 @@ class OGridServer:
             xs = np.sort([g_x_max, g_x_min, l_x_max, l_x_min])
             ys = np.sort([g_y_max, g_y_min, l_y_max, l_y_min])
 
-            start_x = xs[1]
-            end_x = xs[2]
+            start_x, end_x = xs[1:3]  # Grabbing indices 1 and 2
+            start_y, end_y = ys[1:3]
 
-            start_y = ys[1]
-            end_y = ys[2]
-
-            fprint("{},{} {},{}".format(start_x, start_y, end_x, end_y))
+            fprint("ROI {},{} {},{}".format(start_x, start_y, end_x, end_y))
 
             # Assuming resolution has been normalized.
             # Getting the indices to slice the local ogrid.
             l_ogrid_start = transform_between_ogrids([start_x, start_y, 1], global_ogrid, ogrid.nav_ogrid)
-            index_width = round(l_ogrid_start[0] + end_x - start_x)  # I suspect rounding will be the source of error
+            index_width = round(l_ogrid_start[0] + end_x - start_x)  # I suspect rounding will be a source of error
             index_height = round(l_ogrid_start[1] + end_y - start_y)
 
             try:
@@ -260,46 +225,20 @@ class OGridServer:
             except Exception as e:
                 fprint("Exception caught, probably a dimension mismatch:", msg_color='red')
                 print e
+                fprint("w: {}, h: {}".format(global_ogrid.info.width, global_ogrid.info.height), msg_color='red')
 
-            print "=" * 25
-
-
+            print "{}>".format("=" * 25)
 
         np_grid = np.clip(np_grid, -1, 100)         # Clip values for OccupancyGrid bounds
         global_ogrid.data = np_grid.flatten().astype(np.int8)
 
-        print "=" * 50
+        print "\n{}>".format("=" * 50)
         return global_ogrid
-
-    def check_ogrid_topics():
-        pass
 
     def publish(self, *args):
         self.publisher.publish(self.merge_grids())
 
-    # TODO: Make these service calls
-    def add_grid(self, ogrid, interpolate=False):
-        pass
-
-    def pause_grid(self):
-        pass
-
-    def remove_grid(self):
-        pass
-
-    def update_global_map(self):
-        pass
-
-    def reset_global_grid(self):
-        pass
 
 if __name__ == '__main__':
-    #if args.topics is None:
-    #    rospy.logwarn('No input topics provided')
-        # Trigger search for nav_msgs/OccupancyGrid topics currently being published. If there are
-        # none, then exit with logerr.
-    #    pass
-    #elif args.topics is not None:
-
     rospy.init_node('ogrid_server', anonymous=False)
     og_server = OGridServer()

--- a/mission_control/navigator_alarm/navigator_alarm/__init__.py
+++ b/mission_control/navigator_alarm/navigator_alarm/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 
 from alarm_helpers import AlarmBroadcaster
-from alarm_helpers import AlarmListener
+from alarm_helpers import AlarmListener, AlarmListenerTx
 from alarm_helpers import single_alarm
 from . import alarm_handlers
 from alarm_handlers._template import HandlerBase

--- a/mission_control/navigator_alarm/nodes/alarm_handler.py
+++ b/mission_control/navigator_alarm/nodes/alarm_handler.py
@@ -22,7 +22,7 @@ class AlarmHandler(object):
         self.alarm_sub = rospy.Subscriber('/alarm_raise', Alarm, self.alarm_callback, queue_size=100)
         self.alarm_pub = rospy.Publisher('/alarm', Alarm, queue_size=100)
         self.alarms = {}
-        self.alarm_republish_timer = rospy.Timer(rospy.Duration(0.5), self.republish_alarms)
+        self.alarm_republish_timer = rospy.Timer(rospy.Duration(0.05), self.republish_alarms)
 
         self.scenarios = {}
 

--- a/mission_control/navigator_launch/launch/subsystems/lqrrt_node.launch
+++ b/mission_control/navigator_launch/launch/subsystems/lqrrt_node.launch
@@ -6,7 +6,7 @@
 
     <!-- Topics for odometry and an occupancy grid-->
     <param name="odom_topic" value="/odom"/>
-    <param name="ogrid_topic" value="/master_ogrid"/>
+    <param name="ogrid_topic" value="/ogrid_master"/>
 
     <!-- Pose reference topic - this will be the 'carrot' to follow -->
     <param name="ref_topic" value="/lqrrt/ref"/>

--- a/mission_control/navigator_launch/launch/subsystems/lqrrt_node.launch
+++ b/mission_control/navigator_launch/launch/subsystems/lqrrt_node.launch
@@ -6,7 +6,7 @@
 
     <!-- Topics for odometry and an occupancy grid-->
     <param name="odom_topic" value="/odom"/>
-    <param name="ogrid_topic" value="/ogrid"/>
+    <param name="ogrid_topic" value="/master_ogrid"/>
 
     <!-- Pose reference topic - this will be the 'carrot' to follow -->
     <param name="ref_topic" value="/lqrrt/ref"/>

--- a/mission_control/navigator_missions/nav_missions/__init__.py
+++ b/mission_control/navigator_missions/nav_missions/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 import os
 import rospkg
+from navigator_tools import fprint
 
 # Had to use rospkg, os.path.dirname(__file__) wasn't working
 for module in os.listdir(os.path.join(rospkg.RosPack().get_path("navigator_missions"), 'nav_missions/')):
@@ -9,9 +10,10 @@ for module in os.listdir(os.path.join(rospkg.RosPack().get_path("navigator_missi
     try:
         __import__(module[:-3], locals(), globals())
     except Exception as e:
-        print "ERROR in module: {}".format(module)
+        fprint("ERROR in module: {}".format(module), msg_color='red')
         print e, '\n'
 
+del fprint
 del rospkg
 del module
 del os

--- a/mission_control/navigator_missions/nav_missions/coral_survey.py
+++ b/mission_control/navigator_missions/nav_missions/coral_survey.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+from __future__ import division
+
+import txros
+import tf
+import tf.transformations as trns
+import numpy as np
+import navigator_tools
+from navigator_tools import fprint
+from navigator_singleton import pose_editor
+from twisted.internet import defer
+
+WEST = trns.quaternion_matrix(pose_editor.WEST)
+EAST = trns.quaternion_matrix(pose_editor.EAST)
+NORTH = trns.quaternion_matrix(pose_editor.NORTH)
+SOUTH = trns.quaternion_matrix(pose_editor.SOUTH)
+
+@txros.util.cancellableInlineCallbacks
+def main(navigator):
+    result = navigator.fetch_result()
+
+    middle_point = np.array([-10, -70, 0]) #yield navigator.database_query("coral_survey")
+
+    quads_to_search = [1, 2, 3, 4]
+    if (yield navigator.nh.has_param("/mission/coral_survey/quadrants")):
+        quads_to_search = yield navigator.nh.get_param("/mission/coral_survey/quadrants")
+
+    waypoint_from_center = np.array([10 * np.sqrt(2)])
+
+    # Construct waypoint list along NSEW directions then rotate 45 degrees to get a good spot to go to.
+    directions = [EAST, NORTH, WEST, SOUTH]
+    waypoints = []
+    for quad in quads_to_search:
+        mid = navigator.move.set_position(middle_point).set_orientation(directions[quad - 1])
+        waypoints.append(mid.yaw_left(45, "deg").forward(waypoint_from_center).set_orientation(NORTH))
+
+    # Get into the coral survey area
+    yield waypoints[0].go()
+
+    # Publish ogrid with boundaries to stay inside
+    ogrid = OgridFactory(middle_point, draw_borders=True)
+    msg = ogrid.get_message()
+    latched = navigator.latching_publisher("/mission_ogrid", OccupancyGrid, msg)
+
+    searcher = navigator.search("coral_survey", waypoints)
+    yield searcher.start_search(move_type='skid', spotings_req=1)
+
+    fprint("Centering over the thing!", title="CORAL_SURVEY")
+
+    # TODO: Center over the thing.
+
+    boat_position = (yield navigator.tx_pose)[0]
+
+    # TODO: make this easier
+    quad = np.argmin(np.linalg.norm(boat_position - [[w.pose[0][0][0], w.pose[0][1][0],w.pose[0][2][0]] for w in waypoints], axis=1)) + 1
+    fprint("Estimated quadrant: {}".format(quad), title="CORAL_SURVEY", msg_color='green')
+
+    yield navigator.nh.sleep(5)
+    defer.returnValue(result)
+
+
+# This really shouldn't be here - it should be somewhere behind the scenes
+from nav_msgs.msg import OccupancyGrid
+import cv2
+
+class OgridFactory():
+    def __init__(self, center, draw_borders=False):
+        self.resolution = .3
+        self.height, self.width = 60, 60  # meters
+        self.center = center
+
+        self.wall_length = 20  # meters
+        self.walls = None
+
+        # Sets x,y upper and lower bounds and the left and right wall bounds
+        self.make_ogrid_transform()
+        self.make_walls()
+        self.draw_lines(self.walls, -2)
+
+        if draw_borders:
+            self.draw_borders()
+
+    def draw_borders(self):
+        borders = ((-1, -1), (self.grid.shape))
+        cv2.rectangle(self.grid, borders[0], borders[1], 100, 3)
+
+    def make_ogrid_transform(self):
+        origin_x = self.center[0] - 30
+        origin_y = self.center[1] - 30
+        self.origin = navigator_tools.numpy_quat_pair_to_pose([origin_x, origin_y, 0],
+                                                              [0, 0, 0, 1])
+
+        # The grid needs to have it's axes swaped since its row major
+        self.grid = np.zeros((self.height / self.resolution, self.width / self.resolution)) - 1
+
+        # Transforms points from ENU to ogrid frame coordinates
+        self.t = np.array([[1 / self.resolution, 0, -origin_x / self.resolution],
+                           [0, 1 / self.resolution, -origin_y / self.resolution],
+                           [0,               0,            1]])
+
+        self.transform = lambda point: self.t.dot(np.append(point[:2], 1))[:2]
+
+    def make_walls(self):
+        vect = np.array([self.wall_length, 0, 0])
+
+        # Dotting with the negatives seemed to produce cleaner ogrids
+        west_point = EAST[:3, :3].dot(-vect) + self.center
+        east_point = EAST[:3, :3].dot(vect) + self.center
+        north_point = NORTH[:3, :3].dot(vect) + self.center
+        south_point = NORTH[:3, :3].dot(-vect) + self.center
+
+        self.walls = [self.center, west_point,
+                      self.center, east_point,
+                      self.center, north_point,
+                      self.center, south_point]
+
+    def draw_lines(self, points, value):
+        last_wall = None
+        for wall in points:
+            if last_wall is None:
+                last_wall = tuple(self.transform(wall).astype(np.int32))
+                continue
+
+            this_wall = tuple(self.transform(wall).astype(np.int32))
+            cv2.line(self.grid, this_wall, last_wall, value, 1)
+            last_wall = this_wall
+
+    def get_message(self):
+        ogrid = OccupancyGrid()
+        ogrid.header = navigator_tools.make_header(frame="enu")
+        ogrid.info.resolution = self.resolution
+        ogrid.info.height, ogrid.info.width = self.grid.shape
+        ogrid.info.origin = self.origin
+        grid = np.copy(self.grid)
+        ogrid.data = np.clip(grid.flatten(), -100, 100).astype(np.int8)
+
+        return ogrid

--- a/mission_control/navigator_missions/nav_missions/start_gate.py
+++ b/mission_control/navigator_missions/nav_missions/start_gate.py
@@ -28,11 +28,11 @@ class Buoy(object):
 
 
 def get_buoys():
-    f_right = Buoy([10, 0, 0], "green")
+    f_right = Buoy([0, 10, 0], "green")
     f_left = Buoy([10, 10, 0], "red")
 
-    b_right = Buoy([40, 0, 0], "green")
-    b_left = Buoy([40, 10, 0], "red")
+    b_right = Buoy([0, 40, 0], "green")
+    b_left = Buoy([10, 40, 0], "red")
     #rand_1 = Buoy([-23, 48, 0], "green")
     #rand_2 = Buoy([33, -8, 0], "green")
 
@@ -71,7 +71,7 @@ def main(navigator):
 
     # buoys = [Buoy.from_srv(left), Buoy.from_srv(right)]
     #buoys = np.array(get_buoys())
-    # points = [navigator_tools.numpy_to_point(b.position) for b in buoys]
+    points = [navigator_tools.numpy_to_point(b.position) for b in buoys]
 
     pose = yield navigator.tx_pose
     print pose
@@ -85,7 +85,7 @@ def main(navigator):
 
     # Made it this far, make sure the red one is on the left and green on the right ================
     t = txros.tf.Transform.from_Pose_message(navigator_tools.numpy_quat_pair_to_pose(*pose))
-    t_mat = t.as_matrix()[:3, :3]
+    t_mat = t.as_matrix()[:3, :3]  # Probably wont work in general
     f_bl_buoys = [t_mat.dot(buoy.position) for buoy in front]
     b_bl_buoys = [t_mat.dot(buoy.position) for buoy in back]
 

--- a/mission_control/navigator_missions/nav_missions/start_gate.py
+++ b/mission_control/navigator_missions/nav_missions/start_gate.py
@@ -21,22 +21,22 @@ class Buoy(object):
         self.odom = np.array([0, 0, 0])
 
     def __repr__(self):
-        return "BUOY at: {} with color {}".format(self.position, self.color)
+        return "BUOY at: {} with color {}.".format(self.position, self.color)
 
     def distance(self, odom):
         return np.linalg.norm(self.position - odom)
 
 
 def get_buoys():
-    f_right = Buoy([0, 0, 0], "green")
-    f_left = Buoy([0, 10, 0], "red")
+    f_right = Buoy([10, 0, 0], "green")
+    f_left = Buoy([10, 10, 0], "red")
 
-    b_right = Buoy([30, 0, 0], "green")
-    b_left = Buoy([30, 10, 0], "red")
+    b_right = Buoy([40, 0, 0], "green")
+    b_left = Buoy([40, 10, 0], "red")
     #rand_1 = Buoy([-23, 48, 0], "green")
     #rand_2 = Buoy([33, -8, 0], "green")
 
-    buoys = [right, left] #[rand_1, right, rand_2, left]
+    buoys = [f_right, f_left, b_right, b_left]
 
     return buoys
 
@@ -60,47 +60,54 @@ def main(navigator):
     result = navigator.fetch_result()
 
     found_buoys = yield navigator.database_query("start_gate")
-    #print front_buoys
+    print front_buoys
     if found_buoys.found:
-        buoys = map(Buoy.from_srv, found_buoys.objects)
+       buoys = map(Buoy.from_srv, found_buoys.objects)
     else:
-        print "START_GATE: Error 4 - No db buoy response..."
-        result.success = False
-        result.response = "No db buoy response..."
-        return_with(result)
+       print "START_GATE: Error 4 - No db buoy response..."
+       result.success = False
+       result.response = "No db buoy response..."
+       return_with(result)
 
     # buoys = [Buoy.from_srv(left), Buoy.from_srv(right)]
-    buoys = get_buoys()
-    points = [navigator_tools.numpy_to_point(b.position) for b in buoys]
+    #buoys = np.array(get_buoys())
+    # points = [navigator_tools.numpy_to_point(b.position) for b in buoys]
 
+    pose = yield navigator.tx_pose
+    print pose
     # Get the ones closest to us and assume those are the front
-    distances = np.array([b.distance for b in buoys])
-    back = np.sort(distance)[-2:]
-    front = np.sort(distance)[:2]
+    distances = np.array([b.distance(pose[0]) for b in buoys])
+    back = buoys[np.argsort(distances)[-2:]]
+    front = buoys[np.argsort(distances)[:2]]
+
+    points = [navigator_tools.numpy_to_point(b.position) for b in front]
+
 
     # Made it this far, make sure the red one is on the left and green on the right ================
     t = txros.tf.Transform.from_Pose_message(navigator_tools.numpy_quat_pair_to_pose(*pose))
-    f_bl_buoys = [t.transform_point(buoy.position) for buoy in front[:2]]
-    b_bl_buoys = [t.transform_point(buoy.position) for buoy in back[:2]]
+    t_mat = t.as_matrix()[:3, :3]
+    f_bl_buoys = [t_mat.dot(buoy.position) for buoy in front]
+    b_bl_buoys = [t_mat.dot(buoy.position) for buoy in back]
 
     # Angles are w.r.t positive x-axis. Positive is CCW around the z-axis.
     angle_buoys = np.array([np.arctan2(buoy[1], buoy[0]) for buoy in f_bl_buoys])
-    f_left_buoy, f_right_buoy = buoys[np.argmax(angle_buoys)], buoys[np.argmin(angle_buoys)]
+    f_left_buoy, f_right_buoy = front[np.argmax(angle_buoys)], front[np.argmin(angle_buoys)]
 
     angle_buoys = np.array([np.arctan2(buoy[1], buoy[0]) for buoy in b_bl_buoys])
-    b_left_buoy, b_right_buoy = buoys[np.argmax(angle_buoys)], buoys[np.argmin(angle_buoys)]
+    b_left_buoy, b_right_buoy = back[np.argmax(angle_buoys)], back[np.argmin(angle_buoys)]
 
     # Lets plot a course, yarrr
-    between_vector, direction_vector = get_path(f_left_buoy, f_right_buoy)
-    mid_point = left_buoy.position + between_vector / 2
+    f_between_vector, f_direction_vector = get_path(f_left_buoy, f_right_buoy)
+    f_mid_point = f_left_buoy.position + f_between_vector / 2
+    b_between_vector, b_direction_vector = get_path(b_left_buoy, b_right_buoy)
+    b_mid_point = b_left_buoy.position + b_between_vector / 2
 
     #print mid_point
     setup_dist = 20  # Line up with the start gate this many meters infront of the gate.
-    target_dist = 50  # Move this far though the start gate buoys (meters).
-    setup = mid_point - direction_vector * setup_dist
-    target = setup + direction_vector * target_dist
+    setup = f_mid_point - f_direction_vector * setup_dist
+    target = b_mid_point + b_direction_vector * setup_dist
 
-    ogrid = OgridFactory(f_right_buoy.position, f_right_buoy.position, pose[0],
+    ogrid = OgridFactory(f_left_buoy.position, f_right_buoy.position, pose[0],
                          target, left_b_pos=b_left_buoy.position, right_b_pos=b_right_buoy.position)
 
     msg = ogrid.get_message()
@@ -120,10 +127,6 @@ def main(navigator):
     print "START_GATE: Moving!"
 
     yield navigator.move.set_position(target).go()
-
-    yield navigator.nh.set_param("/mission/detect_deliver/Shape", "CIRCLE")
-    yield navigator.nh.set_param("/mmission/detect_deliver/Color", "ANY")
-
     return_with(result)
 
 
@@ -144,8 +147,7 @@ class OgridFactory():
         self.target = target
 
         # Some parameters
-        self.buffer = 50  # length of the "walls" extending outwards from each buoy (m)
-        self.resolution = 3  # cells/meter for ogrid
+        self.resolution = .3  # meters/cell for ogrid
         self.channel_length = 30  # Not sure what this acutally is for the course (m)
         self.edge_buffer = 10
 
@@ -160,11 +162,11 @@ class OgridFactory():
         dx = self.x_upper - self.x_lower
         dy = self.y_upper - self.y_lower
         # The grid needs to have it's axes swaped since its row major
-        self.grid = np.zeros((dy * self.resolution, dx * self.resolution))
+        self.grid = np.zeros((dy / self.resolution, dx / self.resolution))
 
         # Transforms points from ENU to ogrid frame coordinates
-        self.t = np.array([[self.resolution, 0, -self.x_lower * self.resolution],
-                           [0, self.resolution, -self.y_lower * self.resolution],
+        self.t = np.array([[1 / self.resolution, 0, -self.x_lower / self.resolution],
+                           [0, 1 / self.resolution, -self.y_lower / self.resolution],
                            [0,               0,            1]])
         self.transform = lambda point: self.t.dot(np.append(point[:2], 1))[:2]
 
@@ -181,15 +183,9 @@ class OgridFactory():
         b_rot_mat = trns.euler_matrix(0, 0, b_theta)[:3, :3]
 
         # Make the endpoints
-        rot_buffer = b_rot_mat.dot([self.buffer, 0, 0])
+        rot_buffer = b_rot_mat.dot([20, 0, 0])
         endpoint_left_f = self.left_f + rot_buffer
         endpoint_right_f = self.right_f - rot_buffer
-
-        # Define bounds for the grid
-        self.x_lower = min(self.boat_pos[0], endpoint_left_f[0], endpoint_right_f[0], self.target[0]) - self.edge_buffer
-        self.x_upper = max(self.boat_pos[0], endpoint_left_f[0], endpoint_right_f[0], self.target[0]) + self.edge_buffer
-        self.y_lower = min(self.boat_pos[1], endpoint_left_f[1], endpoint_right_f[1], self.target[1]) - self.edge_buffer
-        self.y_upper = max(self.boat_pos[1], endpoint_left_f[1], endpoint_right_f[1], self.target[1]) + self.edge_buffer
 
         # Now lets build some wall points ======================================
 
@@ -213,15 +209,18 @@ class OgridFactory():
         left_cone_point = self.left_f + rot_buffer
         right_cone_point = self.right_f + rot_buffer
 
+        # Define bounds for the grid
+        self.x_lower = min(left_cone_point[0], right_cone_point[0],
+                           endpoint_left_f[0], endpoint_right_f[0], self.target[0]) - self.edge_buffer
+        self.x_upper = max(left_cone_point[0], right_cone_point[0],
+                           endpoint_left_f[0], endpoint_right_f[0], self.target[0]) + self.edge_buffer
+        self.y_lower = min(left_cone_point[1], right_cone_point[1],
+                           endpoint_left_f[1], endpoint_right_f[1], self.target[1]) - self.edge_buffer
+        self.y_upper = max(left_cone_point[1], right_cone_point[1],
+                           endpoint_left_f[1], endpoint_right_f[1], self.target[1]) + self.edge_buffer
+
         self.walls = [self.left_b, self.left_f, left_cone_point, right_cone_point, self.right_f, self.right_b]
-
-
-        # endpoint_left_b = self.left_b + rot_buffer
-        # endpoint_right_b = self.right_b - rot_buffer
-
-        # # These are in ENU by the way
-        # self.left_wall_points = [endpoint_left_f, self.left_f, self.left_b, endpoint_left_b]
-        # self.right_wall_points = [endpoint_right_f, self.right_f, self.right_b, endpoint_right_b]
+        print self.walls
 
     def draw_lines(self, points):
         last_wall = None
@@ -231,7 +230,7 @@ class OgridFactory():
                 continue
 
             this_wall = tuple(self.transform(wall).astype(np.int32))
-            cv2.line(self.grid, this_wall, last_wall, 128, 3)
+            cv2.line(self.grid, this_wall, last_wall, 128, 7)
             last_wall = this_wall
 
     def draw_walls(self):
@@ -274,7 +273,7 @@ class OgridFactory():
     def get_message(self):
         ogrid = OccupancyGrid()
         ogrid.header = navigator_tools.make_header(frame="enu")
-        ogrid.info.resolution = 1 / self.resolution
+        ogrid.info.resolution = self.resolution
         ogrid.info.height, ogrid.info.width = self.grid.shape
         ogrid.info.origin = self.origin
         grid = np.copy(self.grid)

--- a/mission_control/navigator_missions/navigator_singleton/navigator.py
+++ b/mission_control/navigator_missions/navigator_singleton/navigator.py
@@ -93,9 +93,9 @@ class Navigator(object):
         else:
             # We want to make sure odom is working before we continue
             fprint("Waiting for odom...", title="NAVIGATOR")
-            odom = util.wrap_time_notice(self._odom_sub.get_next_message(), 2, "Odom listener", title="NAVIGATOR")
-            enu_odom = util.wrap_time_notice(self._ecef_odom_sub.get_next_message(), 2, "ENU Odom listener", title="NAVIGATOR")
-            bounds = util.wrap_time_notice(self._make_bounds(), 2, "Bounds creation", title="NAVIGATOR")
+            odom = util.wrap_time_notice(self._odom_sub.get_next_message(), 2, "Odom listener")
+            enu_odom = util.wrap_time_notice(self._ecef_odom_sub.get_next_message(), 2, "ENU Odom listener")
+            bounds = util.wrap_time_notice(self._make_bounds(), 2, "Bounds creation")
             yield defer.gatherResults([odom, enu_odom, bounds])  # Wait for all those to finish
 
         defer.returnValue(self)

--- a/mission_control/navigator_missions/navigator_singleton/navigator.py
+++ b/mission_control/navigator_missions/navigator_singleton/navigator.py
@@ -144,7 +144,7 @@ class Navigator(object):
         return self.vision_proxies[request_name].get_response(**kwargs)
 
     def database_query(self, object_name, **kwargs):
-        return self._database_query(navigator_srvs.ObjectDBQuery(name=object_name, **kwargs))
+        return self._database_query(navigator_srvs.ObjectDBQueryRequest(name=object_name, **kwargs))
 
     def change_wrench(self, source):
         return self._change_wrench(navigator_srvs.WrenchSelectRequest(source))

--- a/mission_control/navigator_missions/navigator_singleton/navigator.py
+++ b/mission_control/navigator_missions/navigator_singleton/navigator.py
@@ -81,7 +81,7 @@ class Navigator(object):
             self._database_query = self.nh.get_service_client('/ira_database', navigator_srvs.ObjectDBQuery)
             self._change_wrench = self.nh.get_service_client('/change_wrench', navigator_srvs.WrenchSelect)
         except AttributeError, err:
-            fprint("Error getting service clients in nav singleton init: {}".format(err), title="NAVIGATOR")
+            fprint("Error getting service clients in nav singleton init: {}".format(err), title="NAVIGATOR", msg_color='red')
 
         self.tf_listener = tf.TransformListener(self.nh)
 
@@ -187,7 +187,7 @@ class Navigator(object):
                 self.vision_proxies[name] = VisionProxy(s_client, s_req, s_args, s_switch)
             except Exception, e:
                 err = "Error loading vision sevices: {}".format(e)
-                fprint("" + err, title="NAVIGATOR")
+                fprint("" + err, title="NAVIGATOR", msg_color='red')
 
     @util.cancellableInlineCallbacks
     def _make_alarms(self):
@@ -235,12 +235,12 @@ class Searcher(object):
         if failure.check(defer.CancelledError):
             fprint("Cancelling defer.", title="SEARCHER")
         else:
-            fprint("There was an error.", title="SEARCHER")
+            fprint("There was an error.", title="SEARCHER", msg_color='red')
             fprint(failure.printTraceback())
             # Handle error
 
     @util.cancellableInlineCallbacks
-    def start_search(self, timeout=60, loop=True, spotings_req=2, **kwargs):
+    def start_search(self, timeout=120, loop=True, spotings_req=2, **kwargs):
         fprint("Starting.", title="SEARCHER")
         looker = self._run_look(spotings_req).addErrback(self.catch_error)
         finder = self._run_search_pattern(loop, **kwargs).addErrback(self.catch_error)
@@ -277,7 +277,7 @@ class Searcher(object):
 
         def pattern():
             for pose in self.search_pattern:
-                fprint("going to next position.", title="SEARCHER")
+                fprint("Going to next position.", title="SEARCHER")
                 if type(pose) == list or type(pose) == np.ndarray:
                     yield self.nav.move.relative(pose).go(**kwargs)
                 else:

--- a/mission_control/navigator_missions/navigator_singleton/pose_editor.py
+++ b/mission_control/navigator_missions/navigator_singleton/pose_editor.py
@@ -11,6 +11,7 @@ from rawgps_common.gps import ecef_from_latlongheight, enu_from_ecef
 from lqrrt_ros.msg import MoveGoal
 
 import navigator_tools
+from navigator_tools import fprint
 
 UP = np.array([0.0, 0.0, 1.0], np.float64)
 EAST, NORTH, WEST, SOUTH = [transformations.quaternion_about_axis(np.pi / 2 * i, UP) for i in xrange(4)]
@@ -126,6 +127,11 @@ class PoseEditor2(object):
         return np.linalg.norm(self.position - self.nav.pose[0])
 
     def go(self, *args, **kwargs):
+        if self.nav.killed:
+            # What do we want to do with missions when the boat is killed
+            fprint("Boat is killed, ignoring go command!", title="POSE_EDITOR", msg_color="red")
+            return
+
         self.goal = self.nav._moveto_client.send_goal(self.as_MoveGoal(*args, **kwargs))
         return self.goal.get_result()
 

--- a/mission_control/navigator_missions/navigator_singleton/vision_services.yaml
+++ b/mission_control/navigator_missions/navigator_singleton/vision_services.yaml
@@ -10,11 +10,6 @@ get_shape:
   topic: /vision/get_shapes
   type: GetDockShapes
   args: {'Shape': "CIRCLE", 'Color':"RED"}
-  
-start_gate:
-  topic: /vision/start_gate_buoys
-  type: StartGate
-  args: {}
 
 scan_the_code_activate:
   topic: /vision/scan_the_code_activate
@@ -26,8 +21,7 @@ scan_the_code_status:
     type: ScanTheCodeMission
     args: {}
 
-shooter_lidar:
-  topic: /vision/object_classifier_service
-  type: PerceptionObjectService
-  args: {name: "shooter"}
-
+coral_survey:
+  topic: /vision/coral_survey
+  type: GetDockShape
+  args: {'Shape': "CIRCLE", 'Color':"ANY"}

--- a/mission_control/navigator_missions/nodes/move_command
+++ b/mission_control/navigator_missions/nodes/move_command
@@ -28,12 +28,17 @@ def main():
         help='Point to focus on. See lqrrt documentation for info on how to use this. ex. "[10, 2.3, 1]"')
     parser.add_argument('-s', '--sim', action='store_true',
         help='This will run navigator in sim mode (ie. not wait for odom or enu bounds). Don\'t do this on the boat.')
+    parser.add_argument('-p', '--plantime', type=float,
+        help='Time given to the planner for it\'s first plan.')
 
     args = parser.parse_args(args[1:])
 
     n = yield Navigator(nh)._init(args.sim)
 
     action_kwargs = {'move_type': args.movetype}
+
+    if args.plantime is not None:
+        action_kwargs['initial_plan_time'] = float(args.plantime)
 
     if args.focus is not None:
         focus = np.array(map(float, args.focus[1:-1].split(',')))

--- a/mission_control/navigator_missions/nodes/move_command
+++ b/mission_control/navigator_missions/nodes/move_command
@@ -10,6 +10,7 @@ import nav_missions
 
 import argparse
 
+fprint = navigator_tools.fprint
 
 @util.cancellableInlineCallbacks
 def main():
@@ -47,11 +48,11 @@ def main():
 
     if args.command == 'custom':
         # Let the user input custom commands, the eval may be dangerous so do away with that at some point.
-        print "Moving with the command: {}".format(args.argument)
+        fprint("Moving with the command: {}".format(args.argument), title="MOVE_COMMAND")
         yield eval("n.move.{}.go(move_type='{move_type}')".format(args.argument, **action_kwargs))
 
     elif args.command == 'rviz':
-        print "Moving to last published rviz position"
+        fprint("Moving to last published rviz position", title="MOVE_COMMAND")
         sub = nh.subscribe("/rviz_goal", PoseStamped)
         target_pose = yield sub.get_next_message()
         yield n.move.to_pose(target_pose).go(**action_kwargs)
@@ -72,7 +73,7 @@ def main():
         if station_hold:
             action_kwargs['move_type'] = 'hold'
 
-        print "{}ing {} non-arbitrary unit(s)".format(args.command, amount)
+        fprint("{}ing {} non-arbitrary unit(s)".format(args.command, amount), title="MOVE_COMMAND")
         yield movement(float(amount), unit).go(**action_kwargs)
 
     defer.returnValue(reactor.stop())

--- a/mission_control/navigator_missions/nodes/run_mission
+++ b/mission_control/navigator_missions/nodes/run_mission
@@ -39,9 +39,9 @@ def main():
         result = yield to_run.main(n)
 
         if result is None:
-            fprint("{} finished with no result.", title="MISSION")
+            fprint("{} finished with no result.".format(mission), title="MISSION")
         else:
-            fprint("{} finished with:", title="MISSION")
+            fprint("{} finished with:".format(mission), title="MISSION")
             print result
 
     defer.returnValue(reactor.stop())
@@ -49,3 +49,6 @@ def main():
 if __name__ == '__main__':
     reactor.callWhenRunning(main)
     reactor.run()
+
+    print "\n"
+    fprint("Done!", title="MISSION")

--- a/mission_control/navigator_missions/nodes/run_mission
+++ b/mission_control/navigator_missions/nodes/run_mission
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
+import argparse
+
+import nav_missions
 from txros import util, NodeHandle
 from twisted.internet import defer, reactor
-
 from navigator_singleton.navigator import Navigator
-import nav_missions
 
-import argparse
+from navigator_tools import fprint
 
 
 @util.cancellableInlineCallbacks
@@ -34,13 +35,13 @@ def main():
 
     for mission in args.missions:
         to_run = getattr(nav_missions, mission)
-        print "MISSION: Running Mission!\n"
+        fprint("Running Mission!\n", title="MISSION")
         result = yield to_run.main(n)
 
         if result is None:
-            print "MISSION: {} finished with no result."
+            fprint("{} finished with no result.", title="MISSION")
         else:
-            print "MISSION: {} finished with:"
+            fprint("{} finished with:", title="MISSION")
             print result
 
     defer.returnValue(reactor.stop())

--- a/utils/navigator_tools/navigator_tools/general_helpers.py
+++ b/utils/navigator_tools/navigator_tools/general_helpers.py
@@ -16,6 +16,18 @@ class Colors():
 
         return self.reset
 
+class Seperator():
+    # TODO
+    def __getattr__(self, *args, **kwargs):
+        return
+
+    def equals(self, _len, blank_space=False):
+        text = "{}".format("=" * len)
+        if blank_space:
+            return "\n{}\n".format(text)
+
+        return text
+
 
 def fprint(msg, time=None, title=None, newline=True, msg_color=None):
     time_header = False
@@ -50,6 +62,8 @@ def fprint(msg, time=None, title=None, newline=True, msg_color=None):
         to_print = "{msg}"
 
     if newline:
+        if isinstance(newline, int):
+            msg += "\n" * (newline - 1)  # Since printing implicitly adds a new line
         print to_print.format(time=time_header, title=title_header, msg=msg)
     else:
         # Note, this adds a space at the end.

--- a/utils/navigator_tools/navigator_tools/general_helpers.py
+++ b/utils/navigator_tools/navigator_tools/general_helpers.py
@@ -1,12 +1,32 @@
 import rospy
 
-def print_t(_str, time=None):
-    # Needs a rospy init for ros time
+def print_t(_str, time=None, title=None):
+    time_header = None
+    title_header = False
+
+    if title is not None:
+        title_header = "\033[94m\033[1m{}\033[0m".format(title)
+
     if time is None:
         try:
             time = rospy.Time.now().to_sec()
-            print "\033[1m{}:\033[0m {}".format(time, _str)
+            time_header = "\033[1m{}\033[0m".format(time)
         except rospy.exceptions.ROSInitException:
-            print _str
+            pass
     else:
-        print "\033[1m{}:\033[0m {}".format(time, _str)
+        time_header = "\033[1m{}\033[0m".format(time)
+
+    if title_header and time_header:
+        # (TIME) HEADER: message
+        to_print = "{time} {title}: {msg}"
+    elif time_header:
+        # (TIME): message
+        to_print = "{time}: {msg}"
+    elif title_header:
+        # HEADER: message
+        to_print = "{title}: {msg}"
+    else:
+        # message
+        to_print = "{msg}"
+
+    print to_print.format(time=time_header, title=title_header, msg=_str)

--- a/utils/navigator_tools/navigator_tools/general_helpers.py
+++ b/utils/navigator_tools/navigator_tools/general_helpers.py
@@ -62,7 +62,7 @@ def fprint(msg, time=None, title=None, newline=True, msg_color=None):
         to_print = "{msg}"
 
     if newline:
-        if isinstance(newline, int):
+        if not isinstance(newline, bool):
             msg += "\n" * (newline - 1)  # Since printing implicitly adds a new line
         print to_print.format(time=time_header, title=title_header, msg=msg)
     else:

--- a/utils/navigator_tools/navigator_tools/general_helpers.py
+++ b/utils/navigator_tools/navigator_tools/general_helpers.py
@@ -1,20 +1,40 @@
 import rospy
 
-def print_t(_str, time=None, title=None):
-    time_header = None
+class Colors():
+    # Some cool stuff could happen here
+    red = '\033[91m'
+    blue = '\033[94m'
+    green = '\033[92m'
+    bold = '\033[1m'
+
+    reset = '\033[0m'
+
+    def __getattr__(self, arg):
+        # If we get a non existent color, return the reset color
+        if hasattr(self, arg.lower()):
+            return getattr(self, arg.lower())
+
+        return self.reset
+
+
+def fprint(msg, time=None, title=None, newline=True, msg_color=None):
+    time_header = False
     title_header = False
 
     if title is not None:
-        title_header = "\033[94m\033[1m{}\033[0m".format(title)
+        title_header = "{C.blue}{C.bold}{title}{C.reset}".format(C=Colors, title=title)
+
+    if msg_color is not None:
+        msg = "{color}{msg}{C.reset}".format(color=getattr(Colors(), msg_color), C=Colors, msg=msg)
 
     if time is None:
         try:
             time = rospy.Time.now().to_sec()
-            time_header = "\033[1m{}\033[0m".format(time)
+            time_header = "{C.bold}{time}{C.reset}".format(C=Colors, time=time)
         except rospy.exceptions.ROSInitException:
             pass
     else:
-        time_header = "\033[1m{}\033[0m".format(time)
+        time_header = "{C.bold}{time}{C.reset}".format(C=Colors, time=time)
 
     if title_header and time_header:
         # (TIME) HEADER: message
@@ -29,4 +49,10 @@ def print_t(_str, time=None, title=None):
         # message
         to_print = "{msg}"
 
-    print to_print.format(time=time_header, title=title_header, msg=_str)
+    if newline:
+        print to_print.format(time=time_header, title=title_header, msg=msg)
+    else:
+        # Note, this adds a space at the end.
+        print to_print.format(time=time_header, title=title_header, msg=msg),
+
+print_t = fprint  # For legacy


### PR DESCRIPTION
- Added `fprint` to do some cool fancy printing without 3rd party libraries. You'll notice any mission running or anything that uses the Navigator Singleton will have titles and fancy blue and green text.
- `move.(...).go()` commands will tell you if lqrrt actually got us there or if there was a problem with the trajectory.
- Improved `start_gate` missions and wrote `coral_survey` mission. `coral_survey` right now will take rosparam quadrants to search and simply go to the middle of that quadrant (though better search patterns would be pretty trivial). It requires a fake service server to return found shapes right now.
- Ogrid arbiter is a thing and can take an arbitrary number of ros occupancy grids and combine them! The ogrids can be arbitrarily sized and positioned but _must_ have the same resolution as the master grid (0.3 right now) and can not be rotated (...yet). That node uses dynamic reconfig so we can make changes to the size of the master ogrid and the topics that it subscribes to on the fly! Things in there are pretty messy math wise and there are rounding errors associated with certain sized master ogrids but due to time I decided to go with it since it works for any case we would throw at it.
