### PR TITLE
REMOTE_CONTROL: Controller library and keyboard control

### DIFF
--- a/gnc/navigator_msg_multiplexer/nodes/wrench_arbiter.py
+++ b/gnc/navigator_msg_multiplexer/nodes/wrench_arbiter.py
@@ -2,7 +2,7 @@
 from geometry_msgs.msg import WrenchStamped
 from navigator_msgs.srv import WrenchSelect
 import rospy
-from std_msgs.msg import Bool
+from std_msgs.msg import Bool, String
 
 
 rospy.init_node('wrench_arbiter')
@@ -24,6 +24,7 @@ class WrenchArbiter(object):
         # ROS stuff - Wrench changing service, final output wrench, and the three input sources
         rospy.Service('/change_wrench', WrenchSelect, self.change_wrench)
         self.wrench_pub = rospy.Publisher("/wrench/cmd", WrenchStamped, queue_size=1)
+        self.control_pub = rospy.Publisher("/wrench/current", String, queue_size=1)
         self.learn = rospy.Publisher("learn", Bool, queue_size=1)
 
         # Subscribers to listen for wrenches
@@ -53,6 +54,7 @@ class WrenchArbiter(object):
         self.learn.publish(learn)
         msg.header.frame_id = "/base_link"
         self.wrench_pub.publish(msg)
+        self.control_pub.publish(self.control)
 
     def change_wrench(self, req):
         '''

--- a/gnc/navigator_msg_multiplexer/nodes/wrench_arbiter.py
+++ b/gnc/navigator_msg_multiplexer/nodes/wrench_arbiter.py
@@ -11,22 +11,26 @@ rospy.init_node('wrench_arbiter')
 class WrenchArbiter(object):
 
     def __init__(self):
+
         # Set the three receiving variables
         self.rc_wrench = None
+        self.keyboard_wrench = None
         self.autonomous_wrench = None
 
         # This is what is used to determine which input should be output
         self.control = None
-        self.control_inputs = ['rc', 'autonomous']
+        self.control_inputs = ['rc', 'keyboard', 'autonomous']
 
         # ROS stuff - Wrench changing service, final output wrench, and the three input sources
-        rospy.Service('change_wrench', WrenchSelect, self.change_wrench)
+        rospy.Service('/change_wrench', WrenchSelect, self.change_wrench)
         self.wrench_pub = rospy.Publisher("/wrench/cmd", WrenchStamped, queue_size=1)
         self.learn = rospy.Publisher("learn", Bool, queue_size=1)
 
         # Subscribers to listen for wrenches
         rospy.Subscriber("/wrench/rc", WrenchStamped,
                          lambda msg: self.republish(msg, control_t="rc", learn=False))
+        rospy.Subscriber("/wrench/keyboard", WrenchStamped,
+                         lambda msg: self.republish(msg, control_t="keyboard", learn=False))
         rospy.Subscriber("/wrench/autonomous", WrenchStamped,
                          lambda msg: self.republish(msg, control_t="autonomous", learn=True))
 
@@ -35,6 +39,7 @@ class WrenchArbiter(object):
         Republishes message if it's the correct control type. `learn` will publish to the learn topic
         to start or stop concurrent learning.
         '''
+
         # If there's no control selected, send zeros
         if self.control is None:
             msg.wrench.force.x = 0

--- a/install.sh
+++ b/install.sh
@@ -574,18 +574,21 @@ check_connection() {
 }
 
 set_ros_ip() {
-	LOCAL_IP=\"\`ip route get 1 | awk '{print \$NF; exit}'\`\"
+	LOCAL_IP=\"\`ip route get 192.168.37.0/24 | awk '{print \$NF; exit}'\`\"
+	LOCAL_HOSTNAME=\"\`hostname\`.ad.mil.ufl.edu\"
 
-	# Unsets ROS_HOSTNAME and sets ROS_IP to the IP on this machine's main NIC
-	unset ROS_HOSTNAME
+	# Sets ROS_HOSTNAME to the this machine's hostname
+	export ROS_HOSTNAME=\$LOCAL_HOSTNAME
+
+	# Sets ROS_IP to the IP on this machine's main NIC
 	export ROS_IP=\$LOCAL_IP
 }
 
 unset_ros_ip() {
 
-	# Unsets ROS_IP and sets ROS_HOSTNAME to localhost
+	# Unsets ROS_IP and ROS_HOSTNAME, which will default to localhost
 	unset ROS_IP
-	export ROS_HOSTNAME=localhost
+	unset ROS_HOSTNAME
 }
 
 set_ros_master() {

--- a/mission_control/navigator_launch/launch/gnc.launch
+++ b/mission_control/navigator_launch/launch/gnc.launch
@@ -23,6 +23,7 @@
         <param name="force_scale" value="600" type="double"/>
         <param name="torque_scale" value="500" type="double"/>
     </node>
+    <node pkg="navigator_keyboard_control" type="navigator_keyboard_server.py" name="keyboard_server" output="screen"/>
 
     <node pkg="navigator_tools" type="boat_info.py" name="boat_info_markers" />
 

--- a/utils/navigator_battery_monitor/package.xml
+++ b/utils/navigator_battery_monitor/package.xml
@@ -15,6 +15,4 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>roboteq_msgs</run_depend>
   <run_depend>navigator_alarm</run_depend>
-  <export>
-  </export>
 </package>

--- a/utils/navigator_gui/navigator_gui/dashboard.py
+++ b/utils/navigator_gui/navigator_gui/dashboard.py
@@ -353,6 +353,8 @@ class Dashboard(Plugin):
                 self.update_system_time_status()
                 self.system_time_frame.setStyleSheet(self.colors["green"])
 
+        self.remote.is_timed_out = self.system_time["is_timed_out"]
+
         # Schedules the next instance of this method with a QT timer
         QtCore.QTimer.singleShot(100, self.monitor_system_time)
 

--- a/utils/navigator_gui/navigator_gui/dashboard.py
+++ b/utils/navigator_gui/navigator_gui/dashboard.py
@@ -159,12 +159,6 @@ class Dashboard(Plugin):
         self.wrench_changer = rospy.ServiceProxy('/change_wrench', WrenchSelect)
         self.kill_listener = AlarmListener('kill', self.update_kill_status)
 
-    def timeout_check(function):
-        def decorated_function(self):
-            if (not self.system_time["is_timed_out"]):
-                function(self)
-        return decorated_function
-
     def update_kill_status(self, alarm):
         '''
         Updates the kill status display when there is an update on the kill

--- a/utils/navigator_msgs/CMakeLists.txt
+++ b/utils/navigator_msgs/CMakeLists.txt
@@ -42,6 +42,7 @@ add_service_files(
   ScanTheCodeMission.srv
   ObjectDBQuery.srv
   CameraToLidarTransform.srv
+  KeyboardControl.srv
 )
 
 add_action_files(

--- a/utils/navigator_msgs/srv/KeyboardControl.srv
+++ b/utils/navigator_msgs/srv/KeyboardControl.srv
@@ -1,0 +1,6 @@
+# Used to send keyboard input to the keyboard control server
+string uuid
+int32 keycode
+---
+string generated_uuid
+bool is_locked

--- a/utils/remote_control/navigator_joystick_control/nodes/navigator_joystick.py
+++ b/utils/remote_control/navigator_joystick_control/nodes/navigator_joystick.py
@@ -1,62 +1,39 @@
 #!/usr/bin/env python
 
 
-import itertools
-
-from geometry_msgs.msg import WrenchStamped
-from kill_handling.broadcaster import KillBroadcaster
-from nav_msgs.msg import Odometry
-from navigator_alarm import AlarmBroadcaster
-from navigator_msgs.srv import WrenchSelect, ShooterManual, ShooterManualRequest
-from navigator_msgs.msg import ShooterDoAction, ShooterDoActionGoal
-import rospy
 import actionlib
+from navigator_msgs.msg import ShooterDoAction, ShooterDoActionGoal
+from remote_control_lib import RemoteControl
+import rospy
 from sensor_msgs.msg import Joy
-from std_srvs.srv import SetBool, SetBoolRequest, Trigger, TriggerRequest
+from std_srvs.srv import Trigger, TriggerRequest
 
-rospy.init_node("joystick")
+
+__author__ = "Anthony Olive"
+__maintainer__ = "Anthony Olive"
+__email__ = "anthony@iris-systems.net"
+__copyright__ = "Copyright 2016, MIL"
+__license__ = "MIT"
+
+
+rospy.init_node('joystick')
 
 
 class Joystick(object):
 
     def __init__(self):
-
         self.force_scale = rospy.get_param("~force_scale", 600)
         self.torque_scale = rospy.get_param("~torque_scale", 500)
 
-        self.wrench_choices = itertools.cycle(['rc', 'autonomous'])
-        self.current_pose = Odometry()
-
-        self.active = False
-
-        self.alarm_broadcaster = AlarmBroadcaster()
-        self.kill_alarm = self.alarm_broadcaster.add_alarm(
-            name='kill',
-            action_required=True,
-            severity=0
-        )
-
-        self.station_hold = self.alarm_broadcaster.add_alarm(
-            name='station_hold',
-            action_required=False,
-            severity=3
-        )
-
-        # self.docking_alarm = self.alarm_broadcaster.add_alarm(
-        #     name='docking',
-        #     action_required=True,
-        #     severity=0
-        # )
-
-        self.wrench_pub = rospy.Publisher("/wrench/rc", WrenchStamped, queue_size=1)
-        # rospy.wait_for_service('/change_wrench')
-        self.wrench_changer = rospy.ServiceProxy('/change_wrench', WrenchSelect)
+        self.remote = RemoteControl('joystick', "/wrench/rc")
 
         self.shooter_fire_client = actionlib.SimpleActionClient('/shooter/fire', ShooterDoAction)
         self.shooter_load_client = actionlib.SimpleActionClient('/shooter/load', ShooterDoAction)
         self.shooter_cancel_client = rospy.ServiceProxy('/shooter/cancel', Trigger)
 
-        rospy.Subscriber("joy", Joy, self.joy_cb)
+        rospy.Subscriber("joy", Joy, self.joy_recieved)
+
+        self.active = False
         self.reset()
 
     def reset(self):
@@ -65,11 +42,12 @@ class Joystick(object):
         Sometimes when it disconnects then comes back online, the settings are all
             out of wack.
         '''
-        self.last_change_mode = False
-        self.last_station_hold_state = False
         self.last_kill = False
-        self.last_rc = False
-        self.last_auto = False
+        self.last_station_hold_state = False
+        self.last_change_mode = False
+        self.last_auto_control = False
+        self.last_rc_control = False
+        self.last_keyboard_control = False
         self.last_shooter_shoot = False
         self.last_shooter_cancel = False
         self.last_shooter_load = False
@@ -78,29 +56,23 @@ class Joystick(object):
         self.last_joy = None
         self.active = False
 
-        self.killed = False
-        # self.docking = False
-
-        wrench = WrenchStamped()
-        wrench.header.frame_id = "/base_link"
-        wrench.wrench.force.x = 0
-        wrench.wrench.force.y = 0
-        wrench.wrench.torque.z = 0
-        self.wrench_pub.publish(wrench)
+        self.remote.clear_wrench()
 
     def check_for_timeout(self, joy):
         if self.last_joy is None:
             self.last_joy = joy
             return
 
-        if joy.axes == self.last_joy.axes and \
-           joy.buttons == self.last_joy.buttons:
+        if joy.axes == self.last_joy.axes and joy.buttons == self.last_joy.buttons:
+
             # No change in state
             if rospy.Time.now() - self.last_joy.header.stamp > rospy.Duration(15 * 60):
+
                 # The controller times out after 15 minutes
                 if self.active:
                     rospy.logwarn("Controller Timed out. Hold start to resume.")
                     self.reset()
+
         else:
             joy.header.stamp = rospy.Time.now()  # In the sim, stamps weren't working right
             self.last_joy = joy
@@ -111,24 +83,26 @@ class Joystick(object):
     def shooter_fire_cb(self, status, result):
         rospy.loginfo("Shooter Fire Status={} Success={} Error={}".format(status, result.success, result.error))
 
-    def joy_cb(self, joy):
+    def joy_recieved(self, joy):
         self.check_for_timeout(joy)
 
-        # Handle Button presses
+        # Assigns readable names to the buttons that are used
         start = joy.buttons[7]
         change_mode = bool(joy.buttons[3])  # Y
         kill = bool(joy.buttons[2])  # X
         station_hold = bool(joy.buttons[0])  # A
-        # docking = bool(joy.buttons[1])  # B
         rc_control = bool(joy.buttons[11])  # d-pad left
         auto_control = bool(joy.buttons[12])  # d-pad right
+        keyboard_control = bool(joy.buttons[14])  # d-pad down
         shooter_shoot = joy.axes[5] < -0.9
         shooter_load = bool(joy.buttons[4])
         shooter_cancel = bool(joy.buttons[5])
 
-        # Reset controller state if only start is pressed down for awhile
+        print keyboard_control
+
+        # Reset controller state if only start is pressed down about 3 seconds
         self.start_count += start
-        if self.start_count > 10:  # About 3 seconds
+        if self.start_count > 10:
             rospy.loginfo("Resetting controller state.")
             self.reset()
             self.active = True
@@ -139,86 +113,51 @@ class Joystick(object):
         if not self.active:
             return
 
-        # Change vehicle mode
-        if change_mode == 1 and change_mode != self.last_change_mode:
-            mode = next(self.wrench_choices)
-            rospy.loginfo("Changing Control Mode: {}".format(mode))
-            self.wrench_changer(mode)
+        if kill and kill != self.last_kill:
+            self.remote.toggle_kill()
 
-        if rc_control == 1 and rc_control != self.last_rc:
-            rospy.loginfo("Changing Control to RC")
-            self.wrench_changer("rc")
+        if station_hold and station_hold != self.last_station_hold_state:
+            self.remote.station_hold()
 
-        if auto_control == 1 and auto_control != self.last_auto:
-            rospy.loginfo("Changing Control to Autonomous")
-            self.wrench_changer("autonomous")
+        if change_mode and change_mode != self.last_change_mode:
+            self.remote.select_next_control()
 
-        # Station hold
-        if station_hold == 1 and station_hold != self.last_station_hold_state:
-            rospy.loginfo("Station Holding")
-            self.station_hold.raise_alarm()
-            self.wrench_changer("autonomous")
+        if auto_control and auto_control != self.last_auto_control:
+            self.remote.select_autonomous_control()
 
-        # Turn on full system kill
-        if kill == 1 and kill != self.last_kill:
-            rospy.loginfo("Toggling Kill")
-            if self.killed:
-                self.kill_alarm.clear_alarm()
-            else:
-                self.wrench_changer("rc")
-                self.kill_alarm.raise_alarm(
-                    problem_description='System kill from location: joystick'
-                )
+        if rc_control and rc_control != self.last_rc_control:
+            self.remote.select_rc_control()
 
-            self.killed = not self.killed
-
-        # # Turn on docking mode
-        # if docking == 1 and docking != self.last_docking_state:
-        #     rospy.loginfo("Toggling Docking")
-
-        #     if self.docking:
-        #         self.docking_alarm.clear_alarm()
-        #     else:
-        #         self.docking_alarm.raise_alarm(
-        #             problem_description='Docking kill from location: joystick'
-        #         )
-
-        #     self.docking = not self.docking
+        if keyboard_control and keyboard_control != self.last_keyboard_control:
+            self.remote.select_keyboard_control()
 
         if shooter_shoot and not self.last_shooter_shoot:
             rospy.loginfo("Joystick input : Shoot")
             self.shooter_fire_client.send_goal(goal=ShooterDoActionGoal(), done_cb=self.shooter_fire_cb)
+
         if shooter_load and not self.last_shooter_load:
             rospy.loginfo("Joystick input : Load")
             self.shooter_load_client.send_goal(goal=ShooterDoActionGoal(), done_cb=self.shooter_load_cb)
+
         if shooter_cancel and not self.last_shooter_cancel:
             rospy.loginfo("Joystick input : Cancel")
             self.shooter_cancel_client(TriggerRequest())
 
-        self.last_start = start
-        self.last_change_mode = change_mode
         self.last_kill = kill
         self.last_station_hold_state = station_hold
-        # self.last_docking_state = docking
+        self.last_change_mode = change_mode
         self.last_auto_control = auto_control
-        self.last_rc = rc_control
-        self.last_auto = auto_control
+        self.last_rc_control = rc_control
+        self.last_keyboard_control = keyboard_control
         self.last_shooter_shoot = shooter_shoot
         self.last_shooter_cancel = shooter_cancel
         self.last_shooter_load = shooter_load
 
-        # Handle joystick commands
-        left_stick_x = joy.axes[1]
-        left_stick_y = joy.axes[0]
-        right_stick_y = joy.axes[3]
-
-        wrench = WrenchStamped()
-        wrench.header.frame_id = "/base_link"
-        wrench.header.stamp = joy.header.stamp
-        wrench.wrench.force.x = self.force_scale * left_stick_x
-        wrench.wrench.force.y = self.force_scale * left_stick_y
-        wrench.wrench.torque.z = self.torque_scale * right_stick_y
-        self.wrench_pub.publish(wrench)
+        # Scale joystick input to force and publish a wrench
+        x = joy.axes[1] * self.force_scale
+        y = joy.axes[0] * self.force_scale
+        rotation = joy.axes[3] * self.torque_scale
+        self.remote.publish_wrench(x, y, rotation, joy.header.stamp)
 
 
 if __name__ == "__main__":

--- a/utils/remote_control/navigator_joystick_control/nodes/navigator_joystick.py
+++ b/utils/remote_control/navigator_joystick_control/nodes/navigator_joystick.py
@@ -6,7 +6,6 @@ import rospy
 from sensor_msgs.msg import Joy
 
 
-__author__ = "Anthony Olive"
 __maintainer__ = "Anthony Olive"
 __email__ = "anthony@iris-systems.net"
 __copyright__ = "Copyright 2016, MIL"
@@ -30,9 +29,8 @@ class Joystick(object):
 
     def reset(self):
         '''
-        Used to reset the state of the controller.
-        Sometimes when it disconnects then comes back online, the settings are all
-            out of wack.
+        Used to reset the state of the controller. Sometimes when it
+        disconnects then comes back online, the settings are all out of whack.
         '''
         self.last_kill = False
         self.last_station_hold_state = False

--- a/utils/remote_control/navigator_joystick_control/package.xml
+++ b/utils/remote_control/navigator_joystick_control/package.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <package>
   <name>navigator_joystick_control</name>
-  <version>0.0.0</version>
-  <description>The thrust_mapper package</description>
-  <maintainer email="zachgoins@todo.todo">zachgoins</maintainer>
-  <license>TODO</license>
+  <version>4.0.0</version>
+  <description>A server that controls navigator in response to the /Joy node</description>
+
+  <maintainer email="anthony@iris-systems.net">Anthony Olive</maintainer>
+
+  <license>MIT</license>
+
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
@@ -19,10 +22,4 @@
   <run_depend>navigator_msg_multiplexer</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>navigator_alarm</run_depend>
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/utils/remote_control/navigator_keyboard_control/CMakeLists.txt
+++ b/utils/remote_control/navigator_keyboard_control/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(navigator_keyboard_control)
+
+find_package(catkin REQUIRED COMPONENTS
+	roscpp
+	std_msgs
+	geometry_msgs
+	navigator_msg_multiplexer
+	nav_msgs
+)
+
+catkin_package(
+CATKIN_DEPENDS
+	std_msgs
+	nav_msgs
+	geometry_msgs
+	roscpp
+	navigator_msg_multiplexer
+)
+
+catkin_python_setup()

--- a/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
+++ b/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
@@ -12,7 +12,6 @@ useful feedback and captures key presses to be sent to the server.
 from __future__ import division
 
 import curses
-import uuid
 
 from navigator_msgs.srv import KeyboardControl
 import rospy

--- a/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
+++ b/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
@@ -70,7 +70,7 @@ class KeyboardClient():
         new_keycode = self.screen.getch()
 
         # This eliminates building a buffer of keys that takes forever to process
-        while(new_keycode != -1):
+        while ((new_keycode != -1) and rospy.is_shutdown()):
             keycode = new_keycode
             new_keycode = self.screen.getch()
 

--- a/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
+++ b/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
@@ -46,9 +46,13 @@ class KeyboardClient():
                           "Force Kill:           K          ",
                           "Station Hold:         h          ",
                           "Autonomous Control:   u          ",
-                          "RC Control:           r          ",
+                          "Joystick Control:     j          ",
                           "Keyboard Control:     b          ",
                           "Cycle Control Device: c          ",
+                          "Shooter Load:         r          ",
+                          "Shooter Fire:         f          ",
+                          "Shooter Cancel:       t          ",
+                          "The Big H:            H          ",
                           "Move Forward:         w          ",
                           "Move Backward:        s          ",
                           "Move Port:            a          ",
@@ -73,6 +77,8 @@ class KeyboardClient():
         # The 'q' key can be used to quit the program
         if (keycode == ord('q')):
             rospy.signal_shutdown("The user has closed the keyboard client")
+        elif (keycode == ord('H')):
+            raise NotImplementedError("Kevin, you just threw away your shot!")
 
         return keycode if keycode != -1 else None
 

--- a/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
+++ b/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_client.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+
+'''
+Keyboard Client: The keyboard client connects to the keyboard server in order
+to control NaviGator using a remote keyboard. It is able to lock control of the
+keyboard service to itself by obtaining a UUID that identifies it's service
+calls. Curses is used to display a basic UI in the terminal that gives the user
+useful feedback and captures key presses to be sent to the server.
+'''
+
+
+from __future__ import division
+
+import curses
+import uuid
+
+from navigator_msgs.srv import KeyboardControl
+import rospy
+
+
+__author__ = "Anthony Olive"
+__maintainer__ = "Anthony Olive"
+__email__ = "anthony@iris-systems.net"
+__copyright__ = "Copyright 2016, MIL"
+__license__ = "MIT"
+
+
+rospy.init_node('keyboard_client', anonymous=True)
+
+
+class KeyboardClient():
+
+    def __init__(self, stdscr):
+        self.screen = stdscr
+        self.num_lines = 10
+        self.screen.nodelay(True)
+        curses.curs_set(0)
+
+        self.uuid = ''
+        self.is_locked = False
+
+        self.keyboard_server = rospy.ServiceProxy('/keyboard_control', KeyboardControl)
+
+        self.help_menu = ["Lock:                 L          ",
+                          "Quit:                 q          ",
+                          "Toggle Kill:          k          ",
+                          "Force Kill:           K          ",
+                          "Station Hold:         h          ",
+                          "Autonomous Control:   u          ",
+                          "RC Control:           r          ",
+                          "Keyboard Control:     b          ",
+                          "Cycle Control Device: c          ",
+                          "Move Forward:         w          ",
+                          "Move Backward:        s          ",
+                          "Move Port:            a          ",
+                          "Move Starboard:       d          ",
+                          "Yaw Counterclockwise: arrow up   ",
+                          "Yaw Clockwise:        arrow down "
+                          ]
+
+    def read_key(self):
+        '''
+        Reads the newest key from the buffer and discards all old keys that
+        were not read.
+        '''
+        keycode = -1
+        new_keycode = self.screen.getch()
+
+        # This eliminates building a buffer of keys that takes forever to process
+        while(new_keycode != -1):
+            keycode = new_keycode
+            new_keycode = self.screen.getch()
+
+        # The 'q' key can be used to quit the program
+        if (keycode == ord('q')):
+            rospy.signal_shutdown("The user has closed the keyboard client")
+
+        return keycode if keycode != -1 else None
+
+    def send_key(self, event):
+        '''
+        Sends the key to the keyboard server and stores the returned locked
+        status and generated UUID (if one was received).
+        '''
+        keycode = self.read_key()
+        service_reply = self.keyboard_server(self.uuid, keycode)
+
+        # Flashes the interface if the locked state has changed
+        if (self.is_locked != service_reply.is_locked):
+            self.flash()
+            self.refresh_status_text()
+
+        self.is_locked = service_reply.is_locked
+        if (service_reply.generated_uuid != ''):
+            self.uuid = service_reply.generated_uuid
+            self.refresh_status_text()
+
+        self.refresh_status_text()
+
+    def refresh_status_text(self):
+        '''
+        Updates the status bar text, which consists of the UUID and the current
+        locked state, and a help menu of which key is used for what.
+        '''
+        uuid_string = "UUID: {}".format(self.uuid)
+        locked_string = "Locked: {}".format(self.is_locked)
+        height, width = self.screen.getmaxyx()
+        self.clear()
+
+        # Prints the status bar text
+        if ((height >= 3) and (width >= 3 + len(uuid_string) + len(locked_string))):
+            y, x = 1, int((width - len(uuid_string) - len(locked_string)) / 3)
+            self.screen.addstr(y, x, uuid_string)
+            self.screen.addstr(y, 2 * x + len(uuid_string), locked_string)
+
+        index = 0
+        help_menu_rows = height - 3
+        help_menu_columns = int((width - 1) / len(self.help_menu[0]))
+
+        # Prints the help menu based on how many rows and columns are available in the space of the window
+        for row in range(help_menu_rows):
+            for column in range(help_menu_columns):
+                if (index < len(self.help_menu)):
+                    y, x = row + 3, 1 + column * len(self.help_menu[0])
+                    self.screen.addstr(y, x, self.help_menu[index])
+                    index += 1
+
+    def flash(self):
+        '''
+        Flashes the color of the screen to white for a short time.
+        '''
+        curses.flash()
+
+    def clear(self):
+        '''
+        Clears all text on the screen.
+        '''
+        self.screen.clear()
+
+
+def main(stdscr):
+    rospy.wait_for_service('/keyboard_control')
+    tele = KeyboardClient(stdscr)
+    rospy.Timer(rospy.Duration(0.05), tele.send_key, oneshot=False)
+    rospy.spin()
+
+if __name__ == '__main__':
+    try:
+        curses.wrapper(main)
+    except rospy.ROSInterruptException:
+        pass

--- a/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_server.py
+++ b/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_server.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+'''
+Keyboard Server: The keyboard server enables a client to control NaviGator
+using a remote keyboard. It runs a service that responds to KeyboardControl
+service requests. It manages the currently locked client through the use of
+UUIDs. Only keys received from the client with the locked UUID will be
+executed.
+'''
+
+
+import curses
+import uuid
+
+from navigator_msgs.srv import KeyboardControl
+from remote_control_lib import RemoteControl
+import rospy
+
+
+__author__ = "Anthony Olive"
+__maintainer__ = "Anthony Olive"
+__email__ = "anthony@iris-systems.net"
+__copyright__ = "Copyright 2016, MIL"
+__license__ = "MIT"
+
+
+rospy.init_node('keyboard_server')
+
+
+class KeyboardServer(object):
+
+    def __init__(self):
+        self.force_scale = rospy.get_param("/joystick_wrench/force_scale", 600)
+        self.torque_scale = rospy.get_param("/joystick_wrench/torque_scale", 500)
+
+        self.remote = RemoteControl('keyboard', "/wrench/keyboard")
+        rospy.Service('/keyboard_control', KeyboardControl, self.key_recieved)
+
+        # Initialize this to a random UUID so that a client without a UUID cannot authenticate
+        self.locked_uuid = uuid.uuid4().hex
+
+    def key_recieved(self, req):
+        '''
+        This function handles the process of locking control of the service to
+        one client. If an 'L' is received, a UUID is generated for the client
+        and control of the service is locked to it.
+        '''
+
+        # If the key pressed was L, locks control of the service to the clinet's UUID
+        if (req.keycode == 76):
+
+            # Generates a new UUID for the client if it does not already have one
+            if (req.uuid is ''):
+                self.locked_uuid = uuid.uuid4().hex
+            else:
+                self.locked_uuid = req.uuid
+            return {"generated_uuid": self.locked_uuid, "is_locked": True}
+
+        # If the key was from the client with locked control, pass it to execution
+        elif (req.uuid == self.locked_uuid):
+            self.execute_key(req.keycode)
+            return {"generated_uuid": '', "is_locked": True}
+
+        # Ignore keys sent by a client that has not locked control of the service
+        else:
+            return {"generated_uuid": '', "is_locked": False}
+
+    def execute_key(self, key):
+        '''
+        Executes a remote control action based on the key that was received.
+        '''
+
+        # This block handles the keys tied to control state management
+        if (key == ord('k')):
+            self.remote.toggle_kill()
+        if (key == ord('K')):
+            self.remote.kill()
+        elif (key == ord('h')):
+            self.remote.station_hold()
+        elif (key == ord('u')):
+            self.remote.select_autonomous_control()
+        elif (key == ord('r')):
+            self.remote.select_rc_control()
+        elif (key == ord('b')):
+            self.remote.select_keyboard_control()
+        elif (key == ord('c')):
+            self.remote.select_next_control()
+
+        # This block handles the keys tied to motion
+        if (key == ord('w')):
+            self.remote.publish_wrench(self.force_scale, 0, 0)
+        elif (key == ord('s')):
+            self.remote.publish_wrench(-self.force_scale, 0, 0)
+        elif (key == ord('a')):
+            self.remote.publish_wrench(0, self.force_scale, 0)
+        elif (key == ord('d')):
+            self.remote.publish_wrench(0, -self.force_scale, 0)
+        elif (key == curses.KEY_LEFT):
+            self.remote.publish_wrench(0, 0, self.torque_scale)
+        elif (key == curses.KEY_RIGHT):
+            self.remote.publish_wrench(0, 0, -self.torque_scale)
+
+        # Generates a wrench with zero force or torque if no motion key was pressed
+        else:
+            self.remote.clear_wrench()
+
+
+if __name__ == "__main__":
+    keyboard = KeyboardServer()
+    rospy.spin()

--- a/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_server.py
+++ b/utils/remote_control/navigator_keyboard_control/nodes/navigator_keyboard_server.py
@@ -79,12 +79,18 @@ class KeyboardServer(object):
             self.remote.station_hold()
         elif (key == ord('u')):
             self.remote.select_autonomous_control()
-        elif (key == ord('r')):
+        elif (key == ord('j')):
             self.remote.select_rc_control()
         elif (key == ord('b')):
             self.remote.select_keyboard_control()
         elif (key == ord('c')):
             self.remote.select_next_control()
+        elif (key == ord('r')):
+            self.remote.shooter_load()
+        elif (key == ord('f')):
+            self.remote.shooter_fire()
+        elif (key == ord('t')):
+            self.remote.shooter_cancel()
 
         # This block handles the keys tied to motion
         if (key == ord('w')):

--- a/utils/remote_control/navigator_keyboard_control/package.xml
+++ b/utils/remote_control/navigator_keyboard_control/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package>
+  <name>navigator_keyboard_control</name>
+  <version>1.0.0</version>
+  <description>A keyboard control server and client</description>
+
+  <maintainer email="anthony@iris-systems.net">Anthony Olive</maintainer>
+
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>message_runtime</build_depend>
+  <build_depend>navigator_msg_multiplexer</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>navigator_msg_multiplexer</run_depend>
+  <run_depend>nav_msgs</run_depend>
+  <run_depend>navigator_alarm</run_depend>
+</package>

--- a/utils/remote_control/navigator_keyboard_control/remote_control_lib/__init__.py
+++ b/utils/remote_control/navigator_keyboard_control/remote_control_lib/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+from remote_control_lib import RemoteControl

--- a/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
+++ b/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+
+'''
+Remote Control Library: This object contains all of the common variables and
+functions that are shared by the various remote control devices on NaviGator.
+'''
+
+
+import itertools
+
+from geometry_msgs.msg import WrenchStamped
+from navigator_alarm import AlarmBroadcaster
+from navigator_alarm import AlarmListener
+from navigator_msgs.srv import WrenchSelect
+import rospy
+
+
+__author__ = "Anthony Olive"
+__maintainer__ = "Anthony Olive"
+__email__ = "anthony@iris-systems.net"
+__copyright__ = "Copyright 2016, MIL"
+__license__ = "MIT"
+
+
+class RemoteControl(object):
+
+    def __init__(self, controller_name, wrench_pub=None):
+        self.name = controller_name
+        self.wrench_choices = itertools.cycle(['rc', 'keyboard', 'autonomous'])
+
+        self.alarm_broadcaster = AlarmBroadcaster()
+        self.kill_alarm = self.alarm_broadcaster.add_alarm(
+            name='kill',
+            action_required=True,
+            severity=0
+        )
+        self.station_hold_alarm = self.alarm_broadcaster.add_alarm(
+            name='station_hold',
+            action_required=False,
+            severity=3
+        )
+
+        # rospy.wait_for_service('/change_wrench')
+        self.wrench_changer = rospy.ServiceProxy('/change_wrench', WrenchSelect)
+        self.kill_listener = AlarmListener('kill', self.update_kill_status)
+
+        if (wrench_pub is None):
+            self.wrench_pub = None
+        else:
+            self.wrench_pub = rospy.Publisher(wrench_pub, WrenchStamped, queue_size=1)
+
+        self.is_killed = False
+        self.is_timed_out = False
+        self.clear_wrench()
+
+    def timeout_check(function):
+        def decorated_function(self):
+            if (not self.is_timed_out):
+                function(self)
+        return decorated_function
+
+    def update_kill_status(self, alarm):
+        '''
+        Updates the kill status display when there is an update on the kill
+        alarm. Caches the last displayed kill status to avoid updating the
+        display with the same information twice.
+        '''
+        if (alarm.clear):
+            self.is_killed = False
+        else:
+            self.is_killed = True
+
+    @timeout_check
+    def kill(self):
+        '''
+        Kills the system regardless of what state it is in.
+        '''
+        rospy.loginfo("Toggling Kill")
+        self.wrench_changer("rc")
+        self.kill_alarm.raise_alarm(
+            problem_description='System kill from location: {}'.format(self.name)
+        )
+
+    @timeout_check
+    def toggle_kill(self):
+        '''
+        Toggles the kill status when the toggle_kill_button is pressed.
+        '''
+        rospy.loginfo("Toggling Kill")
+
+        # Responds to the kill broadcaster and checks the status of the kill alarm
+        if self.is_killed:
+            self.kill_alarm.clear_alarm()
+        else:
+            self.wrench_changer("rc")
+            self.kill_alarm.raise_alarm(
+                problem_description='System kill from location: {}'.format(self.name)
+            )
+
+    @timeout_check
+    def station_hold(self):
+        '''
+        Sets the goal point to the current location and switches to autonomous
+        mode in order to stay at that point.
+        '''
+        rospy.loginfo("Station Holding")
+
+        # Trigger station holding at the current pose
+        self.station_hold_alarm.raise_alarm(
+            problem_description='Request to station hold from: {}'.format(self.name)
+        )
+
+        self.wrench_changer("autonomous")
+
+    @timeout_check
+    def select_autonomous_control(self):
+        '''
+        Selects the autonomously generated trajectory as the active controller.
+        '''
+        rospy.loginfo("Changing Control to Autonomous")
+        self.wrench_changer("autonomous")
+
+    @timeout_check
+    def select_rc_control(self):
+        '''
+        Selects the XBox remote joystick as the active controller.
+        '''
+        rospy.loginfo("Changing Control to RC")
+        self.wrench_changer("rc")
+
+    @timeout_check
+    def select_keyboard_control(self):
+        '''
+        Selects the keyboard teleoperation service as the active controller.
+        '''
+        rospy.loginfo("Changing Control to Keyboard")
+        self.wrench_changer("keyboard")
+
+    @timeout_check
+    def select_next_control(self):
+        '''
+        Selects the autonomously generated trajectory as the active controller.
+        '''
+        mode = next(self.wrench_choices)
+        rospy.loginfo("Changing Control Mode: {}".format(mode))
+        self.wrench_changer(mode)
+
+    @timeout_check
+    def publish_wrench(self, x, y, rotation, stamp=None):
+        '''
+        Publishes a wrench to the specified node based on force inputs from the
+        controller.
+        '''
+        if (self.wrench_pub is not None):
+            wrench = WrenchStamped()
+            wrench.header.frame_id = "/base_link"
+            wrench.header.stamp = stamp
+            wrench.wrench.force.x = x
+            wrench.wrench.force.y = y
+            wrench.wrench.torque.z = rotation
+            self.wrench_pub.publish(wrench)
+
+    @timeout_check
+    def clear_wrench(self):
+        '''
+        Publishes a wrench to the specified node based on force inputs from the
+        controller.
+        '''
+        if (self.wrench_pub is not None):
+            wrench = WrenchStamped()
+            wrench.header.frame_id = "/base_link"
+            wrench.wrench.force.x = 0
+            wrench.wrench.force.y = 0
+            wrench.wrench.torque.z = 0
+            self.wrench_pub.publish(wrench)

--- a/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
+++ b/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
@@ -151,6 +151,9 @@ class RemoteControl(object):
         Publishes a wrench to the specified node based on force inputs from the
         controller.
         '''
+        if (stamp is None):
+            stamp = rospy.Time.now()
+
         if (self.wrench_pub is not None):
             wrench = WrenchStamped()
             wrench.header.frame_id = "/base_link"
@@ -169,6 +172,7 @@ class RemoteControl(object):
         if (self.wrench_pub is not None):
             wrench = WrenchStamped()
             wrench.header.frame_id = "/base_link"
+            wrench.header.stamp = rospy.Time.now()
             wrench.wrench.force.x = 0
             wrench.wrench.force.y = 0
             wrench.wrench.torque.z = 0

--- a/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
+++ b/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
@@ -9,11 +9,14 @@ functions that are shared by the various remote control devices on NaviGator.
 import functools
 import itertools
 
+import actionlib
 from geometry_msgs.msg import WrenchStamped
 from navigator_alarm import AlarmBroadcaster
 from navigator_alarm import AlarmListener
+from navigator_msgs.msg import ShooterDoAction, ShooterDoActionGoal
 from navigator_msgs.srv import WrenchSelect
 import rospy
+from std_srvs.srv import Trigger, TriggerRequest
 
 
 __author__ = "Anthony Olive"
@@ -46,15 +49,23 @@ class RemoteControl(object):
         self.kill_listener = AlarmListener('kill', self.update_kill_status)
 
         if (wrench_pub is None):
-            self.wrench_pub = None
+            self.wrench_pub = wrench_pub
         else:
             self.wrench_pub = rospy.Publisher(wrench_pub, WrenchStamped, queue_size=1)
+
+        self.shooter_load_client = actionlib.SimpleActionClient('/shooter/load', ShooterDoAction)
+        self.shooter_fire_client = actionlib.SimpleActionClient('/shooter/fire', ShooterDoAction)
+        self.shooter_cancel_client = rospy.ServiceProxy('/shooter/cancel', Trigger)
 
         self.is_killed = False
         self.is_timed_out = False
         self.clear_wrench()
 
     def timeout_check(function):
+        '''
+        Simple decorator to check whether or not the remote control device is
+        timed out before running the function that was called.
+        '''
         @functools.wraps(function)
         def wrapper(self, *args, **kw):
             return function(self, *args, **kw)
@@ -76,11 +87,20 @@ class RemoteControl(object):
         '''
         Kills the system regardless of what state it is in.
         '''
-        rospy.loginfo("Toggling Kill")
+        rospy.loginfo("Killing")
         self.wrench_changer("rc")
         self.kill_alarm.raise_alarm(
             problem_description='System kill from location: {}'.format(self.name)
         )
+
+    @timeout_check
+    def clear_kill(self, *args, **kw):
+        '''
+        Clears the system kill regardless of what state it is in.
+        '''
+        rospy.loginfo("Reviving")
+        self.wrench_changer("rc")
+        self.kill_alarm.clear_alarm()
 
     @timeout_check
     def toggle_kill(self, *args, **kw):
@@ -145,6 +165,25 @@ class RemoteControl(object):
         mode = next(self.wrench_choices)
         rospy.loginfo("Changing Control Mode: {}".format(mode))
         self.wrench_changer(mode)
+
+    def shooter_load_feedback(self, status, result):
+        rospy.loginfo("Shooter Load Status={} Success={} Error={}".format(status, result.success, result.error))
+
+    @timeout_check
+    def shooter_load(self):
+        self.shooter_load_client.send_goal(goal=ShooterDoActionGoal(), done_cb=self.shooter_load_cb)
+
+    def shooter_fire_feedback(self, status, result):
+        rospy.loginfo("Shooter Fire Status={} Success={} Error={}".format(status, result.success, result.error))
+
+    @timeout_check
+    def shooter_fire(self):
+        self.shooter_fire_client.send_goal(goal=ShooterDoActionGoal(), done_cb=self.shooter_fire_cb)
+
+    @timeout_check
+    def shooter_cancel(self):
+        rospy.loginfo("Canceling shooter requests")
+        self.shooter_cancel_client(TriggerRequest())
 
     @timeout_check
     def publish_wrench(self, x, y, rotation, stamp=None, *args, **kw):

--- a/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
+++ b/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
@@ -6,6 +6,7 @@ functions that are shared by the various remote control devices on NaviGator.
 '''
 
 
+import functools
 import itertools
 
 from geometry_msgs.msg import WrenchStamped
@@ -54,10 +55,10 @@ class RemoteControl(object):
         self.clear_wrench()
 
     def timeout_check(function):
-        def decorated_function(self):
-            if (not self.is_timed_out):
-                function(self)
-        return decorated_function
+        @functools.wraps(function)
+        def wrapper(self, *args, **kw):
+            return function(self, *args, **kw)
+        return wrapper
 
     def update_kill_status(self, alarm):
         '''
@@ -109,8 +110,8 @@ class RemoteControl(object):
         self.station_hold_alarm.raise_alarm(
             problem_description='Request to station hold from: {}'.format(self.name)
         )
-
-        self.wrench_changer("autonomous")
+        rospy.sleep(0.2)
+        self.station_hold_alarm.clear_alarm()
 
     @timeout_check
     def select_autonomous_control(self):

--- a/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
+++ b/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
@@ -72,7 +72,7 @@ class RemoteControl(object):
             self.is_killed = True
 
     @timeout_check
-    def kill(self):
+    def kill(self, *args, **kw):
         '''
         Kills the system regardless of what state it is in.
         '''
@@ -83,7 +83,7 @@ class RemoteControl(object):
         )
 
     @timeout_check
-    def toggle_kill(self):
+    def toggle_kill(self, *args, **kw):
         '''
         Toggles the kill status when the toggle_kill_button is pressed.
         '''
@@ -99,7 +99,7 @@ class RemoteControl(object):
             )
 
     @timeout_check
-    def station_hold(self):
+    def station_hold(self, *args, **kw):
         '''
         Sets the goal point to the current location and switches to autonomous
         mode in order to stay at that point.
@@ -114,7 +114,7 @@ class RemoteControl(object):
         self.station_hold_alarm.clear_alarm()
 
     @timeout_check
-    def select_autonomous_control(self):
+    def select_autonomous_control(self, *args, **kw):
         '''
         Selects the autonomously generated trajectory as the active controller.
         '''
@@ -122,7 +122,7 @@ class RemoteControl(object):
         self.wrench_changer("autonomous")
 
     @timeout_check
-    def select_rc_control(self):
+    def select_rc_control(self, *args, **kw):
         '''
         Selects the XBox remote joystick as the active controller.
         '''
@@ -130,7 +130,7 @@ class RemoteControl(object):
         self.wrench_changer("rc")
 
     @timeout_check
-    def select_keyboard_control(self):
+    def select_keyboard_control(self, *args, **kw):
         '''
         Selects the keyboard teleoperation service as the active controller.
         '''
@@ -138,7 +138,7 @@ class RemoteControl(object):
         self.wrench_changer("keyboard")
 
     @timeout_check
-    def select_next_control(self):
+    def select_next_control(self, *args, **kw):
         '''
         Selects the autonomously generated trajectory as the active controller.
         '''
@@ -147,7 +147,7 @@ class RemoteControl(object):
         self.wrench_changer(mode)
 
     @timeout_check
-    def publish_wrench(self, x, y, rotation, stamp=None):
+    def publish_wrench(self, x, y, rotation, stamp=None, *args, **kw):
         '''
         Publishes a wrench to the specified node based on force inputs from the
         controller.
@@ -165,7 +165,7 @@ class RemoteControl(object):
             self.wrench_pub.publish(wrench)
 
     @timeout_check
-    def clear_wrench(self):
+    def clear_wrench(self, *args, **kw):
         '''
         Publishes a wrench to the specified node based on force inputs from the
         controller.

--- a/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
+++ b/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
@@ -67,8 +67,8 @@ class RemoteControl(object):
         timed out before running the function that was called.
         '''
         @functools.wraps(function)
-        def wrapper(self, *args, **kw):
-            return function(self, *args, **kw)
+        def wrapper(self, *args, **kwargs):
+            return function(self, *args, **kwargs)
         return wrapper
 
     def update_kill_status(self, alarm):
@@ -77,13 +77,10 @@ class RemoteControl(object):
         alarm. Caches the last displayed kill status to avoid updating the
         display with the same information twice.
         '''
-        if (alarm.clear):
-            self.is_killed = False
-        else:
-            self.is_killed = True
+        self.is_killed = not alarm.clear
 
     @timeout_check
-    def kill(self, *args, **kw):
+    def kill(self, *args, **kwargs):
         '''
         Kills the system regardless of what state it is in.
         '''
@@ -94,7 +91,7 @@ class RemoteControl(object):
         )
 
     @timeout_check
-    def clear_kill(self, *args, **kw):
+    def clear_kill(self, *args, **kwargs):
         '''
         Clears the system kill regardless of what state it is in.
         '''
@@ -103,7 +100,7 @@ class RemoteControl(object):
         self.kill_alarm.clear_alarm()
 
     @timeout_check
-    def toggle_kill(self, *args, **kw):
+    def toggle_kill(self, *args, **kwargs):
         '''
         Toggles the kill status when the toggle_kill_button is pressed.
         '''
@@ -119,7 +116,7 @@ class RemoteControl(object):
             )
 
     @timeout_check
-    def station_hold(self, *args, **kw):
+    def station_hold(self, *args, **kwargs):
         '''
         Sets the goal point to the current location and switches to autonomous
         mode in order to stay at that point.
@@ -134,7 +131,7 @@ class RemoteControl(object):
         self.station_hold_alarm.clear_alarm()
 
     @timeout_check
-    def select_autonomous_control(self, *args, **kw):
+    def select_autonomous_control(self, *args, **kwargs):
         '''
         Selects the autonomously generated trajectory as the active controller.
         '''
@@ -142,7 +139,7 @@ class RemoteControl(object):
         self.wrench_changer("autonomous")
 
     @timeout_check
-    def select_rc_control(self, *args, **kw):
+    def select_rc_control(self, *args, **kwargs):
         '''
         Selects the XBox remote joystick as the active controller.
         '''
@@ -150,7 +147,7 @@ class RemoteControl(object):
         self.wrench_changer("rc")
 
     @timeout_check
-    def select_keyboard_control(self, *args, **kw):
+    def select_keyboard_control(self, *args, **kwargs):
         '''
         Selects the keyboard teleoperation service as the active controller.
         '''
@@ -158,7 +155,7 @@ class RemoteControl(object):
         self.wrench_changer("keyboard")
 
     @timeout_check
-    def select_next_control(self, *args, **kw):
+    def select_next_control(self, *args, **kwargs):
         '''
         Selects the autonomously generated trajectory as the active controller.
         '''
@@ -186,7 +183,7 @@ class RemoteControl(object):
         self.shooter_cancel_client(TriggerRequest())
 
     @timeout_check
-    def publish_wrench(self, x, y, rotation, stamp=None, *args, **kw):
+    def publish_wrench(self, x, y, rotation, stamp=None, *args, **kwargs):
         '''
         Publishes a wrench to the specified node based on force inputs from the
         controller.
@@ -204,7 +201,7 @@ class RemoteControl(object):
             self.wrench_pub.publish(wrench)
 
     @timeout_check
-    def clear_wrench(self, *args, **kw):
+    def clear_wrench(self, *args, **kwargs):
         '''
         Publishes a wrench to the specified node based on force inputs from the
         controller.

--- a/utils/remote_control/navigator_keyboard_control/setup.py
+++ b/utils/remote_control/navigator_keyboard_control/setup.py
@@ -1,0 +1,11 @@
+# ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# Fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['remote_control_lib'],
+)
+
+setup(**setup_args)


### PR DESCRIPTION
This PR mainly cleaned up and refactored the remote control system. With the creation of the controller library, any basic interface to a controller (GUI, keyboard, joystick, etc.) can access all of our remote control functions without having to re-implement them locally.

Keyboard control was implemented using a client-server architecture in which one user at a time can 'lock' control of the server by pressing Shift+L. The client does not unlock control, control can be taken by a new keyboard at any time (this is to avoid someone locking control and then leaving without unlocking). All of the key bindings are printed in a help menu. It can be run in a terminal with this command (this includes the terminal emulator in RQT so that the user can drive with cameras or RVIZ in the same window):

    rosrun navigator_keyboard_control navigator_keyboard_client.py

A minor install script patch as well as the wrench_arbiter's /wrench/current node (from lake day 11/13/16) are also included.