### PR TITLE
COMMAND: Circles!

### DIFF
--- a/mission_control/navigator_missions/nav_missions/circle.py
+++ b/mission_control/navigator_missions/nav_missions/circle.py
@@ -5,9 +5,4 @@ import numpy as np
 
 @txros.util.cancellableInlineCallbacks
 def main(navigator):
-    focus = np.array([-10, -10, 0])
-    pattern = navigator.move.circle_point(focus, radius=5)
-
-    for p in pattern:
-        yield p.go(move_type='skid', focus=focus)
-        print "Nexting"
+    res = yield navigator.move.circle_point([5, 0]).go()

--- a/mission_control/navigator_missions/navigator_singleton/pose_editor.py
+++ b/mission_control/navigator_missions/navigator_singleton/pose_editor.py
@@ -92,16 +92,6 @@ def get_valid_point(nav, point):
         return nav.pose[0]
 
 
-class Spiraler(object):
-    def __init__(self, pe, point, *args, **kwargs):
-        self.pe = pe
-        self.point = point
-
-        self.mpr = kwargs.get("mpr", 0)
-        self.direction = kwargs.get("direction", "cw")
-        self.revolutions = kwargs.get("revolutions", 0)
-
-
 class PoseEditor2(object):
     """
     Used to chain movements together

--- a/mission_control/navigator_missions/navigator_singleton/pose_editor.py
+++ b/mission_control/navigator_missions/navigator_singleton/pose_editor.py
@@ -160,7 +160,11 @@ class PoseEditor2(object):
         if self.nav.killed:
             # What do we want to do with missions when the boat is killed
             fprint("Boat is killed, ignoring go command!", title="POSE_EDITOR", msg_color="red")
-            return None
+
+            class Res():
+                failure_reason = 'boat_killed'
+
+            return Res()
         
         if len(self.kwargs) > 0:
             kwargs = dict(kwargs.items() + self.kwargs.items())

--- a/mission_control/navigator_missions/nodes/move_command
+++ b/mission_control/navigator_missions/nodes/move_command
@@ -37,23 +37,23 @@ def main(args):
     if args.command == 'custom':
         # Let the user input custom commands, the eval may be dangerous so do away with that at some point.
         fprint("Moving with the command: {}".format(args.argument), title="MOVE_COMMAND")
-        yield eval("n.move.{}.go(move_type='{move_type}')".format(args.argument, **action_kwargs))
+        res = yield eval("n.move.{}.go(move_type='{move_type}')".format(args.argument, **action_kwargs))
 
     elif args.command == 'rviz':
         fprint("Moving to last published rviz position", title="MOVE_COMMAND")
         sub = nh.subscribe("/rviz_goal", PoseStamped)
         target_pose = yield util.wrap_time_notice(sub.get_next_message(), 2,  "Rviz goal")
-        yield n.move.to_pose(target_pose).go(**action_kwargs)
+        res = yield n.move.to_pose(target_pose).go(**action_kwargs)
 
     elif args.command == 'circle':
-        fprint("Moving in a circle around last clicked_point with radius {} meters".format(args.argument), title="MOVE_COMMAND")
+        fprint("Moving in a circle around last clicked_point", title="MOVE_COMMAND")
         sub = nh.subscribe("/rviz_point", PointStamped)
         target_point = yield util.wrap_time_notice(sub.get_next_message(), 2, "Rviz point")
         target_point = navigator_tools.point_to_numpy(target_point.point)
         circle = n.move.circle_point(target_point, float(args.argument))
-        focus = target_point
-        focus[2] = 1
-        
+        direction = 'cw' if args.argument == '-1' else 'ccw'
+        res = yield n.move.circle_point(target_point, direction).go()
+
     else:
         movement = getattr(n.move, args.command)
 
@@ -71,8 +71,12 @@ def main(args):
             action_kwargs['move_type'] = 'hold'
 
         fprint("{}ing {} non-arbitrary unit(s)".format(args.command, amount), title="MOVE_COMMAND")
-        yield movement(float(amount), unit).go(**action_kwargs)
+        res = yield movement(float(amount), unit).go(**action_kwargs)
 
+    if res.failure_reason is not '':
+        fprint("FAILURE! Reason: {}".format(res.failure_reason), msg_color='green', title="MOVE_COMMAND")
+    else:
+        fprint("Move completed!", msg_color="green", title="MOVE_COMMAND")
     defer.returnValue(reactor.stop())
 
 if __name__ == '__main__':

--- a/mission_control/navigator_missions/nodes/move_command
+++ b/mission_control/navigator_missions/nodes/move_command
@@ -73,8 +73,9 @@ def main(args):
         fprint("{}ing {} non-arbitrary unit(s)".format(args.command, amount), title="MOVE_COMMAND")
         res = yield movement(float(amount), unit).go(**action_kwargs)
 
+    print
     if res.failure_reason is not '':
-        fprint("FAILURE! Reason: {}".format(res.failure_reason), msg_color='green', title="MOVE_COMMAND")
+        fprint("FAILURE! Reason: {}".format(res.failure_reason), msg_color='red', title="MOVE_COMMAND")
     else:
         fprint("Move completed!", msg_color="green", title="MOVE_COMMAND")
     defer.returnValue(reactor.stop())

--- a/mission_control/navigator_missions/nodes/move_command
+++ b/mission_control/navigator_missions/nodes/move_command
@@ -14,32 +14,13 @@ ros_t = lambda d: util.genpy.Duration(d)
 fprint = navigator_tools.fprint
 
 @util.cancellableInlineCallbacks
-def main():
-    nh, args = yield NodeHandle.from_argv_with_remaining("navigator_mission_runner", anonymous=True)
+def main(args):
+    nh, _ = yield NodeHandle.from_argv_with_remaining("navigator_mission_runner", anonymous=True)
     available_missions = [mission_name for mission_name in dir(nav_missions) if not mission_name.startswith('_')]
-
-    parser = argparse.ArgumentParser(description='Command Line Mission Runner',
-        usage='Pass any pose editor command with an argument. \n\t forward 1 (moves forward 1 meter) \n\t backward 2ft (moves backward 2 feet)')
-    parser.add_argument('command', type=str,
-        help='Pose editor command to run')
-    parser.add_argument('argument', type=str, default=0,
-        help='An argument to pass to the command (distance or angle usally). Optionally a unit can be added if a non-standard unit is desired.')
-    parser.add_argument('-m', '--movetype', type=str, default='drive',
-        help='Move type. See lqrrt documentation for info on how to use this.')
-    parser.add_argument('-f', '--focus', type=str,
-        help='Point to focus on. See lqrrt documentation for info on how to use this. If not specified, default to focusing around clicked point. ex. "[10, 2.3, 1]"')
-    parser.add_argument('-s', '--sim', action='store_true',
-        help='This will run navigator in sim mode (ie. not wait for odom or enu bounds). Don\'t do this on the boat.')
-    parser.add_argument('-p', '--plantime', type=float,
-        help='Time given to the planner for it\'s first plan.')
-    parser.add_argument('-b', '--blind', action='store_true',
-        help='Move without looking at the ogrid. DANGEROUS.')
-
-    args = parser.parse_args(args[1:])
 
     n = yield Navigator(nh)._init(args.sim)
 
-    action_kwargs = {'move_type': args.movetype}
+    action_kwargs = {'move_type': args.movetype, 'speed_factor': args.speedfactor}
 
     if args.blind is not None:
         action_kwargs['blind'] = args.blind
@@ -73,11 +54,6 @@ def main():
         focus = target_point
         focus[2] = 1
         
-        circle = n.move.circle(navigator_tools.point_to_numpy(target_point), args.argument)
-        for p in circle:
-            fprint("Moving to next point...")
-            yield p.go(focus=focus, move_type='skid')
-
     else:
         movement = getattr(n.move, args.command)
 
@@ -100,5 +76,26 @@ def main():
     defer.returnValue(reactor.stop())
 
 if __name__ == '__main__':
-    reactor.callWhenRunning(main)
+    parser = argparse.ArgumentParser(description='Command Line Mission Runner',
+        usage='Pass any pose editor command with an argument. \n\t forward 1 (moves forward 1 meter) \n\t backward 2ft (moves backward 2 feet)')
+    parser.add_argument('command', type=str,
+        help='Pose editor command to run')
+    parser.add_argument('argument', type=str, default=0,
+        help='An argument to pass to the command (distance or angle usally). Optionally a unit can be added if a non-standard unit is desired.')
+    parser.add_argument('-m', '--movetype', type=str, default='drive',
+        help='Move type. See lqrrt documentation for info on how to use this.')
+    parser.add_argument('-f', '--focus', type=str,
+        help='Point to focus on. See lqrrt documentation for info on how to use this. If not specified, default to focusing around clicked point. ex. "[10, 2.3, 1]"')
+    parser.add_argument('-s', '--sim', action='store_true',
+        help='This will run navigator in sim mode (ie. not wait for odom or enu bounds). Don\'t do this on the boat.')
+    parser.add_argument('-p', '--plantime', type=float,
+        help='Time given to the planner for it\'s first plan.')
+    parser.add_argument('-b', '--blind', action='store_true',
+        help='Move without looking at the ogrid. DANGEROUS.')
+    parser.add_argument('-sf', '--speedfactor', type=float, default=1.0,
+        help='Speed to execute the command, don\'t go too much higher than 1 on the real boat.')
+
+    args = parser.parse_args()
+
+    reactor.callWhenRunning(lambda: main(args))
     reactor.run()

--- a/mission_control/navigator_missions/nodes/run_mission
+++ b/mission_control/navigator_missions/nodes/run_mission
@@ -23,7 +23,6 @@ def main():
                         help='This allow you to run test missions, rather than real mission.')
     args = parser.parse_args(args[1:])
 
-    print args.test
     if args.test:
         mission_source = nav_missions_test
     else:

--- a/simulation/navigator_gazebo/include/navigator_gazebo/navigator_state_set.hpp
+++ b/simulation/navigator_gazebo/include/navigator_gazebo/navigator_state_set.hpp
@@ -30,7 +30,7 @@ namespace gazebo
 
       ros::NodeHandle nh;
       ros::Subscriber refSub;
-      double modelZOffset;
+      math::Vector3 modelOffset;  // Offset from the (0,0,0) point in the model to base_link
       math::Pose pose;
 
   };

--- a/simulation/navigator_gazebo/launch/goose.launch
+++ b/simulation/navigator_gazebo/launch/goose.launch
@@ -468,5 +468,14 @@
 
     </group>
 
+    <node pkg="nodelet" type="nodelet" name="transform_odometry_sim" args="standalone odometry_utils/transform_odometry">
+        <rosparam>
+            frame_id: /enu
+            child_frame_id: /base_link
+        </rosparam>
+        <remap from="orig_odom" to="model_odom"/>
+    </node>
+
+
     <node pkg="navigator_gazebo" type="gazebo_controller.py" name="gazebo_interface"/>
 </launch>

--- a/simulation/navigator_gazebo/models/wamv/wamv.sdf
+++ b/simulation/navigator_gazebo/models/wamv/wamv.sdf
@@ -222,7 +222,7 @@
     </link>
 
     <plugin name="navigator_state_set" filename="libnavigator_state_set.so">
-      <model_z_offset>1.2</model_z_offset>
+      <model_offset>1.2319 0 1.2</mode_offset>
     </plugin>
 
     <!--

--- a/simulation/navigator_gazebo/nodes/gazebo_controller.py
+++ b/simulation/navigator_gazebo/nodes/gazebo_controller.py
@@ -18,15 +18,15 @@ from rawgps_common import gps
 class GazeboInterface(object):
     def __init__(self, target='wamv::base_link'):
         self.target = target
-        intial_lla = [29.534912, -82.303642, 0]  # In Walhburg
+        intial_lla = [29.534912, -82.303642, 0]  # In Wauhburg
         self.last_ecef = gps.ecef_from_latlongheight(*np.radians(intial_lla))
         self.last_enu = None
         self.last_odom = None
         self.position_offset = None
         
         self.state_sub = rospy.Subscriber('/gazebo/link_states', LinkStates, self.state_cb)
-        self.state_pub = rospy.Publisher('odom', Odometry, queue_size=1)  # This can be thought of as ENU
-        self.absstate_pub = rospy.Publisher('absodom', Odometry, queue_size=1)  # TODO: Make this in ECEF frame instead of ENU
+        self.state_pub = rospy.Publisher('model_odom', Odometry, queue_size=1)
+        self.absstate_pub = rospy.Publisher('absodom', Odometry, queue_size=1)
 
         self.last_odom = None
         self.last_absodom = None
@@ -62,7 +62,7 @@ class GazeboInterface(object):
 
             self.last_odom = Odometry(
                 header=navigator_tools.make_header(frame='/enu'),
-                child_frame_id='/base_link',
+                child_frame_id='/measurement',
                 pose=PoseWithCovariance(
                     pose=navigator_tools.numpy_quat_pair_to_pose(*self.last_enu)
                 ),
@@ -74,7 +74,7 @@ class GazeboInterface(object):
 
             self.last_absodom = Odometry(
                 header=navigator_tools.make_header(frame='/ecef'),
-                child_frame_id='/base_link',
+                child_frame_id='/measurement',
                 pose=PoseWithCovariance(
                     pose=navigator_tools.numpy_quat_pair_to_pose(self.last_ecef, self.last_enu[1])
                 ),

--- a/simulation/navigator_gazebo/src/navigator_state_set.cpp
+++ b/simulation/navigator_gazebo/src/navigator_state_set.cpp
@@ -23,8 +23,10 @@ void StatePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   GZ_ASSERT(_sdf != NULL, "Received NULL SDF pointer");
   this->sdf = _sdf;
 
-  if (this->sdf->HasElement("model_z_offset")){
-    this->modelZOffset = this->sdf->Get<double>("model_z_offset");
+  if (this->sdf->HasElement("model_offset")){
+    this->modelOffset = this->sdf->Get<math::Vector3>("model_offset");
+  }else{
+    this->modelOffset = math::Vector3(0.0, 0.0, 0.0);
   }
 
   // Make sure the ROS node for Gazebo has already been initialized
@@ -33,11 +35,11 @@ void StatePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
 }
 /////////////////////////////////////////////////
 void StatePlugin::PoseRefUpdate(const nav_msgs::OdometryConstPtr& odom) {
-  math::Vector3 pos(odom->pose.pose.position.x, odom->pose.pose.position.y, odom->pose.pose.position.z + this->modelZOffset);
+  math::Vector3 pos(odom->pose.pose.position.x, odom->pose.pose.position.y, odom->pose.pose.position.z);
   math::Quaternion rot(odom->pose.pose.orientation.w, odom->pose.pose.orientation.x,
                        odom->pose.pose.orientation.y, odom->pose.pose.orientation.z);
 
-  this->pose = math::Pose(pos, rot);
+  this->pose = math::Pose(pos + rot.RotateVector(this->modelOffset), rot);
 }
 
 /////////////////////////////////////////////////

--- a/utils/navigator_tools/navigator_tools/msg_helpers.py
+++ b/utils/navigator_tools/navigator_tools/msg_helpers.py
@@ -39,6 +39,8 @@ def rosmsg_to_numpy(rosmsg, keys=None):
             else:
                 break
 
+        assert len(output_array) is not 0, "Input type {} has none of these attributes {}.".format(type(rosmsg).__name__, keys)
+
         return np.array(output_array).astype(np.float32)
 
     else:


### PR DESCRIPTION
Adds support for lqrrt circles. Also fixes most of the gazebo issues I've been having.

__Some important things to note for missions__
- The move formally known as `circle_point` no longer circles a point in discrete move commands like it used to. To keep the same functionality as before (discrete move commands) use `d_circle_point`. The new `circle_point` continuously circles a point at the boat's current distance to the point and the relative orientation to the point. This move will not actively avoid obstacles and will instead return a failure if an obstacle is detected.
- `navigator.move.(...).go()` now returns the action result. The action result has a `failure_reason` attribute which is normally blank (unless something went wrong). 
- Let me know if you have any other questions!