### PR TITLE
KILL: Add kill board package and update alarms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 *.pyc
 *.pyo
 *~
+*.swp
 
 # Eclipse and PyDev project files
 .project

--- a/gnc/navigator_msg_multiplexer/nodes/wrench_arbiter.py
+++ b/gnc/navigator_msg_multiplexer/nodes/wrench_arbiter.py
@@ -64,6 +64,7 @@ class WrenchArbiter(object):
         rospy.loginfo("Server received request for wrench control change - " + req.str)
         self.control = req.str if req.str in self.control_inputs else self.control
 
+        self.control_pub.publish(self.control)
         # Returns the selected control input
         return self.control
 

--- a/hardware_drivers/navigator_kill_board/CMakeLists.txt
+++ b/hardware_drivers/navigator_kill_board/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(navigator_kill_board)
+
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+)
+
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES navigator_kill_board
+#  CATKIN_DEPENDS rospy
+#  DEPENDS system_lib
+)
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+

--- a/hardware_drivers/navigator_kill_board/nodes/driver_node.py
+++ b/hardware_drivers/navigator_kill_board/nodes/driver_node.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+
+import rospy
+
+import threading
+import serial
+
+from std_msgs.msg import String
+
+from navigator_tools import thread_lock
+from navigator_tools import fprint as _fprint
+from navigator_alarm import AlarmBroadcaster, AlarmListener
+from navigator_msgs.msg import KillStatus
+
+fprint = lambda *args, **kwargs: _fprint(time='', *args, **kwargs)
+lock = threading.Lock()
+
+class KillInterface(object):
+    """
+    This handles the comms node between ROS and kill/status embedded board.
+    There are two things running here:
+        1. From ROS: Check current operation mode of the boat and tell that to the light
+        2. From BASE: Check the current kill status from the other sources
+    """
+
+    def __init__(self, port="/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A104OWRY-if00-port0", baud=9600):
+        self.ser = serial.Serial(port=port, baudrate=baud, timeout=0.25)
+        self.ser.flush()
+        
+        self.killstatus_pub = rospy.Publisher("/killstatus", KillStatus, queue_size=1)
+
+        ab = AlarmBroadcaster()
+        self.kill_alarm = ab.add_alarm("hw_kill", problem_description="Hardware kill from a kill switch.")
+        self.disconnect = ab.add_alarm("kill_system_disconnect")
+        
+        self.killed = False
+        # Initial check of kill status
+        self.get_status() 
+
+        self.current_wrencher = ''
+        _set_wrencher = lambda msg: setattr(self, 'current_wrencher', msg.data)
+        rospy.Subscriber("/wrench/current", String, _set_wrencher)
+
+        al = AlarmListener("kill", self.alarm_kill_cb)
+        
+        # Dict of op-codes to functions that need to be run with each code for aysnc responses.
+        self.update_cbs = {'\x10': self.set_kill, '\x11': self.set_unkill, 
+                           '\x12': lambda: True, '\x13': lambda: True, '\x14': lambda: True, '\x15': lambda: True,
+                           '\x16': lambda: True, '\x17': lambda: True, '\x18': lambda: True, '\x19': lambda: True,
+                           '\x1A': lambda: True, '\x1B': lambda: True,
+                           '\x1C': lambda: True, '\x1D': lambda: True,
+                           '\x1E': self.disconnect.clear_alarm, '\x1F': self.disconnect.raise_alarm,}
+        
+        while not rospy.is_shutdown():
+            rospy.sleep(.1)
+            while self.ser.inWaiting() > 0:
+                self.check_buffer()
+             
+            self.control_check()
+            self.get_status()
+
+    def to_hex(self, arg):
+        ret = '\x99'
+        try:
+            ret = hex(ord(arg))
+        except Exception as e:
+            rospy.logerr(e)
+            self.ser.flushInput()
+            self.ser.flushOutput()
+
+        return ret
+
+    def set_kill(self):
+        self.killed = True
+        self.kill_alarm.raise_alarm()
+
+    def set_unkill(self):
+        self.killed = False
+        self.kill_alarm.clear_alarm()
+
+    @thread_lock(lock)
+    def check_buffer(self):
+        # The board appears to not be return async data
+        resp = self.ser.read(1)
+        if resp in self.update_cbs:
+            fprint(self.to_hex(resp), title="CHECKBUFFER")
+            self.update_cbs[resp]()
+
+    @thread_lock(lock)
+    def request(self, write_str, recv_str=None):
+        """
+        Deals with requesting data and checking if the response matches some `recv_str`.
+        Returns True or False depending on the response.
+        With no `recv_str` passed in the raw result will be returned.
+        """
+        fprint("Writing {}...".format(self.to_hex(write_str)), title="REQUEST")
+        self.ser.write(write_str)
+    
+        fprint("Reading response...", title="REQUEST")
+        resp = self.ser.read(1)
+
+        if recv_str is None:
+            fprint("Response received: {}".format(self.to_hex(resp)), msg_color='blue')
+            return resp
+        
+        if resp in recv_str:
+            # It matched!
+            fprint("Response matched!", title="REQUEST", msg_color='green')
+            return True
+
+        self.ser.flushOutput()
+        # Result didn't match
+        fprint("Response didn't match. Expected: {}, got: {}.".format(self.to_hex(recv_str), self.to_hex(resp)), msg_color='red')
+        return False
+
+    def alarm_kill_cb(self, alarm):
+        # Ignore the alarm if it came from us
+        if alarm.node_name == rospy.get_name() and not alarm.clear:
+            return
+        
+        if not alarm.clear:
+            self.request('\x45')
+        else:
+            self.request('\x46')
+    
+    def control_check(self, *args):
+        # Update status light with current control
+        
+        if self.current_wrencher == 'autonomous':
+            self.request('\x42', '\x52')
+        elif self.current_wrencher in ['keyboard', 'rc']:
+            self.request('\x41', '\x51')
+        else:
+            self.request('\x40', '\x50')
+
+    def get_status(self):
+        """
+        Request an updates all current status indicators
+        """
+        # Overall kill status
+        overall = self.request('\x21')
+        pf = self.request('\x22')
+        pa = self.request('\x23')
+        sf = self.request('\x24')
+        sa = self.request('\x25')
+        remote = self.request('\x26')
+        computer = self.request('\x27')
+        #remote_conn = self.request('\x28')
+        
+        killstatus = KillStatus()
+        killstatus.overall = ord(overall) == 1
+        killstatus.pf = ord(pf) == 1
+        killstatus.pa = ord(pa) == 1
+        killstatus.sf = ord(sf) == 1
+        killstatus.sa = ord(sa) == 1
+        killstatus.remote = ord(remote) == 1
+        killstatus.computer = ord(computer) == 1
+        self.killstatus_pub.publish(killstatus)
+
+        # If any of the kill options (except the computer) are true, raise the alarm.
+        if 5 >= sum(map(ord, [pf, pa, sf, sa, remote])) >= 1:
+            self.set_kill()
+        else:
+            self.set_unkill()
+
+    def ping(self):
+        fprint("Pinging...")
+        
+        if self.request('\x20', '\x30'):
+            fprint("Ping response!", msg_color='green')
+        else:
+            fprint("No ping response found", msg_color='red')
+
+
+
+if __name__ == '__main__':
+    rospy.init_node("kill_interface")
+    k = KillInterface() 
+    rospy.spin()

--- a/hardware_drivers/navigator_kill_board/package.xml
+++ b/hardware_drivers/navigator_kill_board/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package>
+  <name>navigator_kill_board</name>
+  <version>1.0.0</version>
+  <description>The navigator_kill_board package</description>
+
+  <maintainer email="matthew.langford95@gmail.com">Matt Langford</maintainer>
+
+
+  <license>MIT</license>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <run_depend>rospy</run_depend>
+
+  <export>
+  </export>
+</package>

--- a/mission_control/navigator_alarm/navigator_alarm/__init__.py
+++ b/mission_control/navigator_alarm/navigator_alarm/__init__.py
@@ -7,8 +7,7 @@ from . import alarm_handlers
 from alarm_handlers._template import HandlerBase
 
 meta_alarms_inv = {
-    'kill': ('network-timeout', 'power-failure', 'battery-voltage', 'covariance-scale'),
-    'notify': ('fail-log',)
+    'kill': ('rc_kill', 'hw_kill'),
 }
 
 meta_alarms = {}

--- a/mission_control/navigator_alarm/navigator_alarm/alarm_helpers.py
+++ b/mission_control/navigator_alarm/navigator_alarm/alarm_helpers.py
@@ -202,12 +202,10 @@ class AlarmListener(object):
             We've gotten an alarm, but don't panic! If it's one of the alarms we are listening for,
             pass the alarm to the function callback with any specified args.
         '''
-
         if alarm.alarm_name not in self.known_alarms:
             self.known_alarms.append(alarm.alarm_name)
-
-        found_alarm = self.callback_linker.get(alarm.alarm_name, None)
-
+        
+        found_alarm = self.callback_linker.get(alarm.alarm_name)
         if found_alarm is None:
             return
 
@@ -222,7 +220,7 @@ class AlarmListener(object):
         else:
             # Otherwise do nothing
             return
-
+        
         callback = found_alarm['callback']
         callback(alarm)
 

--- a/mission_control/navigator_alarm/nodes/alarm_handler.py
+++ b/mission_control/navigator_alarm/nodes/alarm_handler.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 import rospy
 import json
+import navigator_tools
 from navigator_msgs.msg import Alarm
-from navigator_alarm import alarm_handlers, meta_alarms, HandlerBase
+from navigator_alarm import alarm_handlers, meta_alarms, meta_alarms_inv, HandlerBase
 import datetime
 import inspect
 import sys
@@ -17,15 +18,18 @@ class AlarmHandler(object):
             - Handle alarms in sequence (Don't get stuck in the callback)
             - bag (if set) EVERY single alarm received
         '''
-        rospy.init_node('alarm_handler')
         # Queue size is large because you bet your ass we are addressing every alarm
         self.alarm_sub = rospy.Subscriber('/alarm_raise', Alarm, self.alarm_callback, queue_size=100)
         self.alarm_pub = rospy.Publisher('/alarm', Alarm, queue_size=100)
+        
         self.alarms = {}
-        self.alarm_republish_timer = rospy.Timer(rospy.Duration(0.05), self.republish_alarms)
-
         self.scenarios = {}
 
+        for alarm in meta_alarms_inv:
+           self.alarms[alarm] = Alarm(alarm_name=alarm, clear=True, header=navigator_tools.make_header()) 
+
+        self.alarm_republish_timer = rospy.Timer(rospy.Duration(0.05), self.republish_alarms)
+        
         # Go through everything in the navigator_alarm.alarm_handlers package
         for candidate_alarm_name in dir(alarm_handlers):
             # Discard __* nonsense
@@ -42,19 +46,12 @@ class AlarmHandler(object):
         alarms = self.alarms
         for alarm_name, alarm in alarms.items():
             self.alarm_pub.publish(alarm)
-
-            if alarm.clear:
+            
+            if alarm.clear and alarm.alarm_name not in meta_alarms_inv:
+                rospy.logwarn("Deleting alarm: {}".format(alarm.alarm_name))
                 del self.alarms[alarm_name]
 
     def alarm_callback(self, alarm):
-
-        # -- > We don't have to remove cleared alarms
-
-        # if alarm.clear:
-        #     rospy.logwarn("Clearing {}".format(alarm.alarm_name))
-        #     if alarm.alarm_name in self.alarms.keys():
-        #         self.alarms.pop(alarm.alarm_name)
-        #     return
         self.alarms[alarm.alarm_name] = alarm
 
         time = alarm.header.stamp
@@ -97,7 +94,22 @@ class AlarmHandler(object):
         # Handle meta-alarms (See Sub8 wiki)
         meta_alarm = meta_alarms.get(alarm.alarm_name, None)
         if meta_alarm is not None:
-            self.alarms[meta_alarm] = alarm
+            # Meta alarms require one of each alarm raiser clears before the meta alarm clears
+            self.alarms[meta_alarm].header = alarm.header
+            if not alarm.clear:
+                rospy.logwarn("Raising meta-alarm: {}".format(meta_alarm))
+                self.alarms[meta_alarm].clear = False
+            else:
+                alarms_needed = meta_alarms_inv[meta_alarm]
+                # Make sure all the required alarms are clear to clear the meta alarm
+                for req_alarm in alarms_needed:
+                    a = self.alarms.get(req_alarm, None)
+                    if a is not None and not a.clear:
+                        break
+                else:
+                    rospy.logwarn("Clearing meta-alarm: {}".format(meta_alarm))
+                    self.alarms[meta_alarm].clear = True
+
             scenario = self.scenarios.get(meta_alarm, None)
             if scenario is not None:
                 if alarm.clear:
@@ -106,7 +118,8 @@ class AlarmHandler(object):
                     scenario.handle(time, parameters, alarm.alarm_name)
 
 
-
 if __name__ == '__main__':
+    rospy.init_node('alarm_handler')
+    rospy.sleep(.01)  # For the clock to get registered (w/o this was causing issues)
     alarm_handler = AlarmHandler()
     rospy.spin()

--- a/mission_control/navigator_alarm/nodes/alarm_handler.py
+++ b/mission_control/navigator_alarm/nodes/alarm_handler.py
@@ -96,6 +96,7 @@ class AlarmHandler(object):
         if meta_alarm is not None:
             # Meta alarms require one of each alarm raiser clears before the meta alarm clears
             self.alarms[meta_alarm].header = alarm.header
+            self.alarms[meta_alarm].node_name = alarm.node_name
             if not alarm.clear:
                 rospy.logwarn("Raising meta-alarm: {}".format(meta_alarm))
                 self.alarms[meta_alarm].clear = False

--- a/mission_control/navigator_alarm/nodes/event_listeners/odom_kill_listener.py
+++ b/mission_control/navigator_alarm/nodes/event_listeners/odom_kill_listener.py
@@ -21,8 +21,7 @@ class OdomKillListener(object):
         self.odom_discontinuity = False
         self.killed = False
         self.odom_listener = rospy.Subscriber('/odom', Odometry, self.got_odom_msg, queue_size=1)
-        self.clear_kill_listener = AlarmListener('kill', self.clear_kill)
-        self.alarm_broadcaster, self.alarm = single_alarm('kill', severity=3,
+        self.alarm_broadcaster, self.alarm = single_alarm('odom_loss', severity=3,
                                                           problem_description="Killing wamv due to unreliable state estimation")
         rospy.Timer(rospy.Duration(0.1), self.check)
 

--- a/mission_control/navigator_alarm/test_alarms/test.py
+++ b/mission_control/navigator_alarm/test_alarms/test.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import rospy
+from navigator_alarm import AlarmListener
+
+rospy.init_node("alarm_test")
+
+def kill(alarm):
+    print "KILL cleared: {}".format(alarm.clear)
+
+def rc_kill(alarm):
+    print "RCKILL clear: {}".format(alarm.clear)
+
+al = AlarmListener()
+al.add_listener("kill", kill)
+al.add_listener("rc_kill", rc_kill)
+
+rospy.spin()

--- a/mission_control/navigator_launch/launch/subsystems/hardware_drivers.launch
+++ b/mission_control/navigator_launch/launch/subsystems/hardware_drivers.launch
@@ -2,4 +2,6 @@
   <include file="$(find navigator_launch)/launch/subsystems/shooter.launch" />
   <include file="$(find navigator_launch)/launch/subsystems/hydrophones.launch" />
   <include file="$(find navigator_launch)/launch/subsystems/motor_controller.launch"/>
+  
+  <node pkg="navigator_kill_board" type="driver_node.py" name="killboard_interface"/>
 </launch>

--- a/mission_control/navigator_missions/nav_missions/circle.py
+++ b/mission_control/navigator_missions/nav_missions/circle.py
@@ -5,4 +5,8 @@ import numpy as np
 
 @txros.util.cancellableInlineCallbacks
 def main(navigator):
-    res = yield navigator.move.circle_point([5, 0]).go()
+    pos = yield navigator.tx_pose
+    circle = navigator.move.d_circle_point(pos[0] + 1, 5, direction='cw')
+
+    for c in circle:
+        yield c.go(move_type='skid')

--- a/mission_control/navigator_missions/navigator_singleton/__init__.py
+++ b/mission_control/navigator_missions/navigator_singleton/__init__.py
@@ -2,9 +2,9 @@
 import os
 
 for module in os.listdir(os.path.dirname(__file__)):
-    if module == '__init__.py' or module[-3:] != '.py' or module[-1] == '~':
+   if module == '__init__.py' or module[-3:] != '.py' or module[-1] == '~':
         continue
-    __import__(module[:-3], locals(), globals())
+   __import__(module[:-3], locals(), globals())
 
 del module
 del os

--- a/mission_control/navigator_missions/navigator_singleton/navigator.py
+++ b/mission_control/navigator_missions/navigator_singleton/navigator.py
@@ -74,7 +74,8 @@ class Navigator(object):
 
         self.enu_bounds = None
 
-        self.killed = False
+        self.killed = '?'
+        self.odom_killed = '?'
 
     @util.cancellableInlineCallbacks
     def _init(self, sim):
@@ -241,10 +242,15 @@ class Navigator(object):
 
         fprint("Alarm listener created, listening to alarms: ", title="NAVIGATOR")
 
+        self.alarm_listener.add_listener("odom_kill", lambda alarm: setattr(self, 'odom_killed', not alarm.clear))
         self.alarm_listener.add_listener("kill", lambda alarm: setattr(self, 'killed', not alarm.clear))
+        
         yield self.alarm_listener.wait_for_alarm("kill", timeout=.5)
+        yield self.alarm_listener.wait_for_alarm("odom_kill", timeout=.5)
         fprint("\tkill :", newline=False)
         fprint(self.killed)
+        fprint("\todom_kill :", newline=False)
+        fprint(self.odom_killed)
 
 class VisionProxy(object):
     def __init__(self, client, request, args, switch):

--- a/mission_control/navigator_missions/navigator_singleton/navigator.py
+++ b/mission_control/navigator_missions/navigator_singleton/navigator.py
@@ -246,10 +246,10 @@ class Navigator(object):
         self.alarm_listener.add_listener("kill", lambda alarm: setattr(self, 'killed', not alarm.clear))
         
         yield self.alarm_listener.wait_for_alarm("kill", timeout=.5)
-        yield self.alarm_listener.wait_for_alarm("odom_kill", timeout=.5)
+        yield self.alarm_listener.wait_for_alarm("odom_loss", timeout=.5)
         fprint("\tkill :", newline=False)
         fprint(self.killed)
-        fprint("\todom_kill :", newline=False)
+        fprint("\todom_loss :", newline=False)
         fprint(self.odom_killed)
 
 class VisionProxy(object):

--- a/mission_control/navigator_missions/navigator_singleton/navigator.py
+++ b/mission_control/navigator_missions/navigator_singleton/navigator.py
@@ -75,7 +75,7 @@ class Navigator(object):
         self.enu_bounds = None
 
         self.killed = '?'
-        self.odom_killed = '?'
+        self.odom_loss = '?'
 
     @util.cancellableInlineCallbacks
     def _init(self, sim):
@@ -242,7 +242,7 @@ class Navigator(object):
 
         fprint("Alarm listener created, listening to alarms: ", title="NAVIGATOR")
 
-        self.alarm_listener.add_listener("odom_kill", lambda alarm: setattr(self, 'odom_killed', not alarm.clear))
+        self.alarm_listener.add_listener("odom_loss", lambda alarm: setattr(self, 'odom_loss', not alarm.clear))
         self.alarm_listener.add_listener("kill", lambda alarm: setattr(self, 'killed', not alarm.clear))
         
         yield self.alarm_listener.wait_for_alarm("kill", timeout=.5)
@@ -250,7 +250,7 @@ class Navigator(object):
         fprint("\tkill :", newline=False)
         fprint(self.killed)
         fprint("\todom_loss :", newline=False)
-        fprint(self.odom_killed)
+        fprint(self.odom_loss)
 
 class VisionProxy(object):
     def __init__(self, client, request, args, switch):

--- a/mission_control/navigator_missions/navigator_singleton/pose_editor.py
+++ b/mission_control/navigator_missions/navigator_singleton/pose_editor.py
@@ -147,7 +147,7 @@ class PoseEditor2(object):
         return np.linalg.norm(self.position - self.nav.pose[0])
 
     def go(self, *args, **kwargs):
-        if self.nav.killed:
+        if self.nav.killed == True and self.nav.odom_killed == True:
             # What do we want to do with missions when the boat is killed
             fprint("Boat is killed, ignoring go command!", title="POSE_EDITOR", msg_color="red")
 

--- a/mission_control/navigator_missions/navigator_singleton/pose_editor.py
+++ b/mission_control/navigator_missions/navigator_singleton/pose_editor.py
@@ -19,6 +19,7 @@ UP = np.array([0.0, 0.0, 1.0], np.float64)
 EAST, NORTH, WEST, SOUTH = [transformations.quaternion_about_axis(np.pi / 2 * i, UP) for i in xrange(4)]
 UNITS = {'m': 1, 'ft': 0.3048, 'yard': 0.9144, 'rad': 1, 'deg': 0.0174533}
 
+
 def normalized(x):
     x = np.array(x)
     if max(map(abs, x)) == 0:
@@ -147,7 +148,7 @@ class PoseEditor2(object):
         return np.linalg.norm(self.position - self.nav.pose[0])
 
     def go(self, *args, **kwargs):
-        if self.nav.killed == True and self.nav.odom_killed == True:
+        if self.nav.killed == True or self.nav.odom_loss == True:
             # What do we want to do with missions when the boat is killed
             fprint("Boat is killed, ignoring go command!", title="POSE_EDITOR", msg_color="red")
 
@@ -158,7 +159,7 @@ class PoseEditor2(object):
         
         if len(self.kwargs) > 0:
             kwargs = dict(kwargs.items() + self.kwargs.items())
-        kwargs['speed_factor'] = [.7, .7, .7]
+        
         goal = self.nav._moveto_client.send_goal(self.as_MoveGoal(*args, **kwargs))
         self.result = goal.get_result()
         return self.result

--- a/mission_control/navigator_missions/nodes/move_command
+++ b/mission_control/navigator_missions/nodes/move_command
@@ -20,7 +20,7 @@ def main(args):
 
     n = yield Navigator(nh)._init(args.sim)
 
-    action_kwargs = {'move_type': args.movetype, 'speed_factor': args.speedfactor}
+    action_kwargs = {'move_type': args.movetype}#, 'speed_factor': args.speedfactor}
 
     action_kwargs['blind'] = args.blind
 

--- a/utils/navigator_msgs/CMakeLists.txt
+++ b/utils/navigator_msgs/CMakeLists.txt
@@ -24,6 +24,7 @@ add_message_files(
   PerceptionObjectArray.msg
   DockShape.msg
   DockShapes.msg
+  KillStatus.msg
 )
 
 add_service_files(

--- a/utils/navigator_msgs/msg/KillStatus.msg
+++ b/utils/navigator_msgs/msg/KillStatus.msg
@@ -1,0 +1,7 @@
+bool overall
+bool pf
+bool pa
+bool sf
+bool sa
+bool remote
+bool computer

--- a/utils/remote_control/navigator_joystick_control/nodes/navigator_joystick.py
+++ b/utils/remote_control/navigator_joystick_control/nodes/navigator_joystick.py
@@ -22,10 +22,10 @@ class Joystick(object):
         self.torque_scale = rospy.get_param("~torque_scale", 500)
 
         self.remote = RemoteControl("joystick", "/wrench/rc")
+        self.reset()
         rospy.Subscriber("joy", Joy, self.joy_recieved)
 
         self.active = False
-        self.reset()
 
     def reset(self):
         '''

--- a/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
+++ b/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
@@ -34,7 +34,7 @@ class RemoteControl(object):
 
         self.alarm_broadcaster = AlarmBroadcaster()
         self.kill_alarm = self.alarm_broadcaster.add_alarm(
-            name="kill",
+            name="rc_kill",
             action_required=True,
             severity=0
         )
@@ -46,7 +46,7 @@ class RemoteControl(object):
 
         # rospy.wait_for_service("/change_wrench")
         self.wrench_changer = rospy.ServiceProxy("/change_wrench", WrenchSelect)
-        self.kill_listener = AlarmListener("kill", self._update_kill_status)
+        self.kill_listener = AlarmListener("rc_kill", self._update_kill_status)
 
         if (wrench_pub is None):
             self.wrench_pub = wrench_pub


### PR DESCRIPTION
Some noteworthy things changed in this PR:
- Meta alarms require none of the "sub" alarms that could raise them are raised in order for the meta alarm to be cleared. For example, if the `kill` meta-alarm is triggered by the `rc_kill` and `hw_kill` alarms, both of those alarms must be clear in order for the `kill` alarm to also be clear. This was important for the kill board node.
- Speaking of, the kill board node is here and it connected with Daniel Duggers kill board to connect it with ROS. I tested different control methods (RC and Autonomous) to make sure it lit up correctly. Also I tested different alarm set ups, everything seemed to work.
- One weird thing I did was not include `odom_kill` in the kill meta alarm because this would effectively disable RC mode if odom went down - which is an undesired behavior, so it's handled separately.