### PR TITLE
DETECT DELIVER: Shoot in random shape if correct not found

### DIFF
--- a/mission_control/navigator_launch/CMakeLists.txt
+++ b/mission_control/navigator_launch/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(navigator_launch)
-
-find_package(catkin REQUIRED)
-
+find_package(catkin REQUIRED roslaunch)
+roslaunch_add_file_check(launch)
 catkin_package()

--- a/mission_control/navigator_launch/launch/subsystems/cameras/cameras.launch
+++ b/mission_control/navigator_launch/launch/subsystems/cameras/cameras.launch
@@ -1,4 +1,8 @@
 <launch>
-    <include file="$(find navigator_launch)/launch/subsystems/cameras/front_stereo.launch"/>
+    <include file="$(find navigator_launch)/launch/subsystems/cameras/front_stereo.launch">
+        <arg name="stereo_left"  value="False" />
+        <arg name="stereo_right" value="True" />
+    </include>
     <include file="$(find navigator_launch)/launch/subsystems/cameras/right.launch"/>
+    <include file="$(find navigator_launch)/launch/subsystems/cameras/downward.launch"/>
 </launch>

--- a/mission_control/navigator_launch/launch/subsystems/cameras/front_stereo.launch
+++ b/mission_control/navigator_launch/launch/subsystems/cameras/front_stereo.launch
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="stereo_left"  default="True" />
+  <arg name="stereo_right" default="True" />
   <!-- Nodelet Manager Process -->
   <group ns="stereo">
     <node pkg="nodelet" type="nodelet" name="camera_nodelet_manager"
@@ -7,7 +9,7 @@
     <!-- Left/Right Camera Driver Nodelets -->
 
     <!-- LEFT CAMERA-->
-    <node pkg="nodelet" type="nodelet" name="left_camera1394_nodelet"
+    <node if="$(arg stereo_left)" pkg="nodelet" type="nodelet" name="left_camera1394_nodelet"
           args="load camera1394/driver camera_nodelet_manager">
           <param name="guid" value="00b09d0100e84a44"/>
           <param name="camera_info_url" value="file://$(find navigator_launch)/launch/subsystems/cameras/calibration/${NAME}.yaml"/>
@@ -25,10 +27,10 @@
     </node>
 
     <!-- RIGHT CAMERA -->
-    <node pkg="nodelet" type="nodelet" name="right_camera1394_nodelet"
+    <node if="$(arg stereo_right)" pkg="nodelet" type="nodelet" name="right_camera1394_nodelet"
           args="load camera1394/driver camera_nodelet_manager">
           <param name="guid" value="00b09d0100e84a42"/>
-	  <param name="camera_info_url" value="file://$(find navigator_launch)/launch/subsystems/cameras/calibration/${NAME}.yaml"/>
+          <param name="camera_info_url" value="file://$(find navigator_launch)/launch/subsystems/cameras/calibration/${NAME}.yaml"/>
           <param name="frame_id" value="stereo_right_cam"/>
           <param name="num_dma_buffers" value="10"/>
           <param name="video_mode" value="format7_mode4"/>
@@ -49,46 +51,46 @@
     <!--    2. Clean up -->
 
     <!-- LEFT CAMERA -->
-   <!-- Bayer color decoding -->
-   <node pkg="nodelet" type="nodelet" name="left_image_proc_debayer"
+    <!-- Bayer color decoding -->
+    <node if="$(arg stereo_left)" pkg="nodelet" type="nodelet" name="left_image_proc_debayer"
         args="load image_proc/debayer camera_nodelet_manager">
      <remap from="image_color" to="left/image_color" />
      <remap from="image_mono" to="left/image_mono" />
      <remap from="image_raw" to="left/image_raw" />
-   </node>
+    </node>
 
-   <!-- mono rectification -->
-    <node pkg="nodelet" type="nodelet" name="left_image_proc_rect"
+    <!-- mono rectification -->
+    <node if="$(arg stereo_left)" pkg="nodelet" type="nodelet" name="left_image_proc_rect"
           args="load image_proc/rectify camera_nodelet_manager">
       <remap from="image_mono" to="left/image_mono" />
       <remap from="image_rect" to="left/image_rect" />
     </node>
 
     <!-- color rectification -->
-    <node pkg="nodelet" type="nodelet" name="left_image_proc_rect_color"
+    <node if="$(arg stereo_left)" pkg="nodelet" type="nodelet" name="left_image_proc_rect_color"
           args="load image_proc/rectify camera_nodelet_manager">
       <remap from="image_mono" to="left/image_color" />
       <remap from="image_rect" to="left/image_rect_color" />
     </node>
 
     <!-- RIGHT CAMERA -->
-   <!-- Bayer color decoding -->
-   <node pkg="nodelet" type="nodelet" name="right_image_proc_debayer"
+    <!-- Bayer color decoding -->
+    <node if="$(arg stereo_right)" pkg="nodelet" type="nodelet" name="right_image_proc_debayer"
         args="load image_proc/debayer camera_nodelet_manager">
      <remap from="image_color" to="right/image_color" />
      <remap from="image_mono" to="right/image_mono" />
      <remap from="image_raw" to="right/image_raw" />
-   </node>
+    </node>
 
     <!-- mono rectification -->
-    <node pkg="nodelet" type="nodelet" name="right_image_proc_rect"
+    <node if="$(arg stereo_right)" pkg="nodelet" type="nodelet" name="right_image_proc_rect"
           args="load image_proc/rectify camera_nodelet_manager">
       <remap from="image_mono" to="right/image_mono" />
       <remap from="image_rect" to="right/image_rect" />
     </node>
 
     <!-- color rectification -->
-    <node pkg="nodelet" type="nodelet" name="right_image_proc_rect_color"
+    <node if="$(arg stereo_right)" pkg="nodelet" type="nodelet" name="right_image_proc_rect_color"
           args="load image_proc/rectify camera_nodelet_manager">
       <remap from="image_mono" to="right/image_color" />
       <remap from="image_rect" to="right/image_rect_color" />

--- a/mission_control/navigator_launch/package.xml
+++ b/mission_control/navigator_launch/package.xml
@@ -6,6 +6,7 @@
   <maintainer email="zach.a.goins@gmail.com">zachgoins</maintainer>
   <license>TODO</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roslaunch</build_depend>
   <export>
   </export>
 </package>

--- a/perception/navigator_vision/nodes/camera_to_lidar/CameraLidarTransformer.cpp
+++ b/perception/navigator_vision/nodes/camera_to_lidar/CameraLidarTransformer.cpp
@@ -46,11 +46,23 @@ bool CameraLidarTransformer::transformServiceCallback(navigator_msgs::CameraToLi
     res.error = "NO CAMERA INFO";
     return true;
   }
+  if (camera_info.header.frame_id != req.header.frame_id)
+  {
+    res.success = false;
+    res.error = "DIFFERENT FRAME ID THAN SUBSCRIBED CAMERA";
+    return true;
+  }
   visualization_msgs::MarkerArray markers;
   sensor_msgs::PointCloud2ConstPtr scloud = lidarCache.getElemAfterTime(req.header.stamp);
   if (!scloud) {
     res.success = false;
     res.error =  navigator_msgs::CameraToLidarTransform::Response::CLOUD_NOT_FOUND;
+    return true;
+  }
+  if (!tfBuffer.canTransform(req.header.frame_id, "velodyne", ros::Time(0), ros::Duration(1)))
+  {
+    res.success = false;
+    res.error = "NO TRANSFORM";
     return true;
   }
   geometry_msgs::TransformStamped transform = tfBuffer.lookupTransform(req.header.frame_id, "velodyne", ros::Time(0));


### PR DESCRIPTION
- As detect deliver runs, it remembers what shapes it saw. If after circling around the platform the correct shape/color is not identified, it will shoot in one of the targets it saw while circling
- Catch some potential edge case errors in CameraLidarTransformer
- Update the Searcher class in navigator to take a custom looking callback. I don't think anyone else uses this, so it won't break anything.
- Everything has been tested in bags without any regressions