### PR TITLE
PINGER, DOCKING, DETECT DELIVER, SHOOTER, PERCEPTION, TOOLS: kevins work from compeition through 12/14

### DIFF
--- a/mission_control/navigator_launch/launch/bag.launch
+++ b/mission_control/navigator_launch/launch/bag.launch
@@ -30,7 +30,7 @@
     <node name="action_server" pkg="navigator_tools" type="fake_action_server.py" output="screen"/>
 
     <group if="$(arg oa)">
-        <node name="lidar" pkg="navigator_lidar_oa" type="lidar"/>
+        <include file="$(find navigator_launch)/launch/subsystems/object_classification.launch" />
         <node name="ogrid_arbiter" pkg="navigator_msg_multiplexer" type="ogrid_arbiter.py" output="screen" respawn="true"/>
     </group>
 </launch>

--- a/mission_control/navigator_launch/launch/perception.launch
+++ b/mission_control/navigator_launch/launch/perception.launch
@@ -1,8 +1,8 @@
 <launch>
   <!-- start dock symbols vision services -->
   <include file="$(find navigator_launch)/launch/subsystems/perception/dock_shapes.launch" />
+  <include file="$(find navigator_launch)/launch/subsystems/perception/dock_shapes_front.launch" />
   <!--node name="start_gate_vision" pkg="navigator_controller" type="start_gate_manual.py" respawn="True"/-->
 
-  <node name="scan_the_code" pkg="navigator_vision" type="model_detector.py" respawn="True"/>
   <node name="pinger_finder" pkg="navigator_vision" type="pinger_finder.py" />
 </launch>

--- a/mission_control/navigator_launch/launch/subsystems/perception/dock_shapes_front.launch
+++ b/mission_control/navigator_launch/launch/subsystems/perception/dock_shapes_front.launch
@@ -1,0 +1,13 @@
+<launch>
+  <node pkg="navigator_vision" type="shape_identification" name="shape_identification_front">
+    <rosparam file="$(find navigator_launch)/launch/subsystems/perception/shape_finder_front.yaml" />
+    <param name="symbol_camera" value="/stereo/right/image_rect_color"/>
+    <param name="image_transport" value="raw" />
+    <param name="get_shapes_topic" value="/vision/get_shapes_front" />
+    <param name="auto_start" value="false" />
+  </node>
+  <node pkg="navigator_vision" type="camera_to_lidar" name="camera_lidar_transformer_front_right">
+    <param name="camera_to_lidar_transform_topic" value="/camera_to_lidar/stereo_right_cam" />
+    <param name="camera_info_topic" value="/stereo/right/camera_info" />
+  </node>
+</launch>

--- a/mission_control/navigator_launch/launch/subsystems/perception/shape_finder.yaml
+++ b/mission_control/navigator_launch/launch/subsystems/perception/shape_finder.yaml
@@ -1,7 +1,7 @@
-tracker:
-  min_count: 15
-  max_distance_gap: 5
-  max_seen_gap_seconds: 0.5
+tracking:
+  min_count: 5
+  max_distance_gap: 25
+  max_seen_gap_seconds: 2
 size:
   height: 300
   width: 480

--- a/mission_control/navigator_launch/launch/subsystems/perception/shape_finder_front.yaml
+++ b/mission_control/navigator_launch/launch/subsystems/perception/shape_finder_front.yaml
@@ -1,0 +1,93 @@
+tracker:
+  min_count: 15
+  max_distance_gap: 5
+  max_seen_gap_seconds: 0.5
+size:
+  height: 300
+  width: 480
+roi:
+  x_offset: 0
+  y_offset: 0
+  height: 300
+  width: 480
+grayscale:
+  red_hue_min: 0
+  red_hue_max: 180
+  blue_hue: 120
+  green_hue: 60
+  blur_size: 7
+  canny:
+    thresh1: 60
+    thresh2: 100
+  min_contour_area: .0001
+  circle:
+    enclosing_circle_error_threshold: 0.2
+  triangle:
+    rect_error_threshold: 0.1
+    side_error_threshold: 0.1
+    angle_mean_error_threshold: 5
+    angle_var_error_threshold: 10
+  cross:
+    rect_error_threshold: 0.2
+    side_error_threshold: 0.2
+    angle_mean_error_threshold: 5
+    angle_var_error_threshold: 5
+blur_size: 3
+erode_size: 3
+dilate_size: 3
+bilateral_filter:
+  diameter: 5
+  sigma_color: 20
+  sigma_space: 20
+cross:
+  bounding_area:
+    low: 0.43
+    high: 0.57
+  min_area: 300
+triangle:
+  bounding_area:
+    low: 0.41
+    high: 0.50
+  min_area: 300
+circle:
+  bounding_area:
+    low: 0.7
+    high: 0.8
+  min_area: 300
+hsv:
+  red1:
+    low:
+      H: 154.1369
+      S: 63.75
+      V: 0
+    high:
+      H: 180
+      S: 166.464
+      V: 255
+  red2:
+    low:
+      H: 0
+      S: 63.75
+      V: 0
+    high:
+      H: 70.6631
+      S: 166.464
+      V: 255
+  blue:
+    low:
+      H: 79.0357
+      S: 60.2055
+      V: 0
+    high:
+      H: 139.2024
+      S: 173.553
+      V: 255
+  green:
+    low:
+      H: 39.7738
+      S: 7.089
+      V: 0.0
+    high:
+      H: 131.7619
+      S: 63.75
+      V: 53.1165

--- a/mission_control/navigator_launch/launch/subsystems/perception/shape_finder_front.yaml
+++ b/mission_control/navigator_launch/launch/subsystems/perception/shape_finder_front.yaml
@@ -1,7 +1,7 @@
-tracker:
-  min_count: 15
-  max_distance_gap: 5
-  max_seen_gap_seconds: 0.5
+tracking:
+  min_count: 5
+  max_distance_gap: 25
+  max_seen_gap_seconds: 2
 size:
   height: 300
   width: 480

--- a/mission_control/navigator_missions/nav_missions/detect_deliver.py
+++ b/mission_control/navigator_missions/nav_missions/detect_deliver.py
@@ -14,17 +14,20 @@ from image_geometry import PinholeCameraModel
 from visualization_msgs.msg import Marker,MarkerArray
 import navigator_tools
 from navigator_tools import fprint, MissingPerceptionObject
+import genpy
 
 class DetectDeliverMission:
     # Note, this will be changed when the shooter switches to actionlib
-    shoot_distance_meters = 2.7
+    shoot_distance_meters = 3.1
     theta_offset = np.pi / 2.0
     spotings_req = 1
     circle_radius = 10
+    platform_radius = 0.925
     search_timeout_seconds = 300
     SHAPE_CENTER_TO_BIG_TARGET = 0.42
     SHAPE_CENTER_TO_SMALL_TARGET = -0.42
     NUM_BALLS = 4
+    LOOK_AT_TIME = 5
 
     def __init__(self, navigator):
         self.navigator = navigator
@@ -64,29 +67,94 @@ class DetectDeliverMission:
         self.waypoint_res = res
 
     @txros.util.cancellableInlineCallbacks
-    def circle_search(self):
-        print "Starting circle search"
-        #yield self.navigator.move.look_at(navigator_tools.rosmsg_to_numpy(self.waypoint_res.objects[0].position)).go()
-        pattern = self.navigator.move.d_circle_point(navigator_tools.rosmsg_to_numpy(
-            self.waypoint_res.objects[0].position), radius=self.circle_radius, theta_offset=self.theta_offset, direction='cw')
-        yield next(pattern).go()
-        searcher = self.navigator.search(search_pattern=pattern, looker=self.search_shape)
-        yield searcher.start_search(timeout=self.search_timeout_seconds, spotings_req=self.spotings_req, move_type="skid", loop=False)
-        print "Ended Circle Search"
+    def get_any_shape(self):
+        shapes = yield self.get_shape()
+        if shapes.found:
+            for shape in shapes.shapes.list:
+                normal_res = yield self.get_normal(shape)
+                if normal_res.success:
+                    enu_cam_tf = yield self.navigator.tf_listener.get_transform('/enu', '/'+shape.header.frame_id, shape.header.stamp)
+                    self.update_shape(shape, normal_res, enu_cam_tf)
+                    defer.returnValue( ((shape.Shape, shape.Color), self.identified_shapes[(shape.Shape, shape.Color)]) )
+                else:
+                    fprint("Normal not found Error={}".format(normal_res.error), title="DETECT DELIVER", msg_color='red')
+        else:
+            fprint("shape not found Error={}".format(shapes.error), title="DETECT DELIVER", msg_color="red")
+        defer.returnValue(False)
 
-        #  fprint("Starting Circle Search", title="DETECT DELIVER",  msg_color='green')
-        #  yield self.navigator.move.look_at(navigator_tools.rosmsg_to_numpy(self.waypoint_res.objects[0].position)).yaw_left(90, unit='deg').go()
-        #  self.navigator.move.d_circle_point(navigator_tools.rosmsg_to_numpy(self.waypoint_res.objects[0].position), self.circle_radius).go()
-        #  while not (yield self.is_found()):
-            #  fprint("Shape not found Error={}".format(self.resp.error), title="DETECT DELIVER", msg_color='red')
-        #  yield self.navigator.move.stop()
-        #  fprint("Ended Circle Search", title="DETECT DELIVER",  msg_color='green')
+    @txros.util.cancellableInlineCallbacks
+    def circle_search(self):
+        platform_np = navigator_tools.rosmsg_to_numpy(self.waypoint_res.objects[0].position)
+        yield self.navigator.move.look_at(platform_np).set_position(platform_np).backward(self.circle_radius).yaw_left(90,unit='deg').go(move_type="drive")
+
+        done_circle = False
+        @txros.util.cancellableInlineCallbacks
+        def do_circle():
+            yield self.navigator.move.circle_point(platform_np).go()
+            done_circle = True
+
+        circle_defer = do_circle()
+        while not done_circle:
+            res = yield self.get_any_shape()
+            if res == False:
+                yield self.navigator.nh.sleep(0.25)
+                continue
+            fprint("Shape ({}found, using normal to look at other 3 shapes if needed".format(res[0]), title="DETECT DELIVER", msg_color="green")
+            #  circle_defer.cancel()
+            shape_color, found_shape_pose = res
+            if self.correct_shape(shape_color):
+                self.shape_pose = found_shape_pose
+                return
+            #Pick other 3 to look at
+            rot_right = np.array([[0, -1], [1, 0]])
+            (shape_point, shape_normal) = found_shape_pose
+            rotated_norm = np.append(rot_right.dot(shape_normal[:2]), 0)
+            center_point = shape_point - shape_normal * (self.platform_radius/2.0)
+            
+            point_opposite_side = center_point - shape_normal * self.circle_radius
+            move_opposite_side = self.navigator.move.set_position(point_opposite_side).look_at(center_point).yaw_left(90, unit='deg')
+
+            left_or_whatever_point = center_point + rotated_norm * self.circle_radius
+            move_left_or_whatever = self.navigator.move.set_position(left_or_whatever_point).look_at(center_point).yaw_left(90, unit='deg')
+
+            right_or_whatever_point = center_point - rotated_norm * self.circle_radius
+            move_right_or_whatever = self.navigator.move.set_position(right_or_whatever_point).look_at(center_point).yaw_left(90, unit='deg')
+
+            yield self.search_sides((move_left_or_whatever, move_opposite_side, move_right_or_whatever))
+            return
+        fprint("No shape found after complete circle",title="DETECT DELIVER", msg_color='red')
+        raise Exception("No shape found on platform")
 
     def update_shape(self, shape_res, normal_res, tf):
        self.identified_shapes[(shape_res.Shape, shape_res.Color)] = self.get_shape_pos(normal_res, tf)
 
-    def correct_shape(self, shape):
-        return (self.Color == "ANY" or self.Color == shape.Color) and (self.Shape == "ANY" or self.Shape == shape.Shape)
+    def correct_shape(self, (shape,color)):
+        return (self.Color == "ANY" or self.Color == color) and (self.Shape == "ANY" or self.Shape == shape)
+
+    @txros.util.cancellableInlineCallbacks
+    def search_side(self):
+        fprint("Searching side",title="DETECT DELIVER", msg_color='green')
+        start_time = self.navigator.nh.get_time()
+        while self.navigator.nh.get_time() - start_time < genpy.Duration(self.LOOK_AT_TIME):
+            res = yield self.get_any_shape()
+            if not res == False:
+                defer.returnValue(res)
+            yield self.navigator.nh.sleep(0.1)
+        defer.returnValue(False)
+
+    @txros.util.cancellableInlineCallbacks
+    def search_sides(self, moves):
+        for move in moves:
+            yield move.go(move_type="drive")
+            res = yield self.search_side()
+            if res == False:
+                fprint("No shape found on side",title="DETECT DELIVER", msg_color='red')
+                continue
+            shape_color, found_pose = res
+            if self.correct_shape(shape_color):
+                self.shape_pose = found_pose
+                return
+            fprint("Saw (Shape={}, Color={}) on this side".format(shape_color[0], shape_color[1]),title="DETECT DELIVER", msg_color='green')
 
     @txros.util.cancellableInlineCallbacks
     def search_shape(self):
@@ -130,7 +198,7 @@ class DetectDeliverMission:
         move = self.navigator.move.set_position(goal_point).set_orientation(goal_orientation).forward(self.target_offset_meters)
         move = move.left(-shooter_baselink_tf._p[1]).forward(-shooter_baselink_tf._p[0]) #Adjust for location of shooter
         fprint("Aligning to shoot at {}".format(move), title="DETECT DELIVER", msg_color='green')
-        yield move.go(move_type="skid")
+        yield move.go(move_type="drive")
 
     def get_shape(self):
         return self.navigator.vision_proxies["get_shape"].get_response(Shape="ANY", Color="ANY")
@@ -162,7 +230,7 @@ class DetectDeliverMission:
         defer.returnValue(normal_res)
 
     def normal_is_sane(self, vector3):
-         return abs(navigator_tools.rosmsg_to_numpy(vector3)[1]) < 0.2
+         return abs(navigator_tools.rosmsg_to_numpy(vector3)[1]) < 0.4
 
     @txros.util.cancellableInlineCallbacks
     def shoot_all_balls(self):
@@ -187,8 +255,8 @@ class DetectDeliverMission:
 
 @txros.util.cancellableInlineCallbacks
 def setup_mission(navigator):
-    color = "ANY"
-    shape = "ANY"
+    color = "RED"
+    shape = "TRIANGLE"
     #color = yield navigator.mission_params["scan_the_code_color3"].get()
     fprint("Setting search shape={} color={}".format(shape, color), title="DETECT DELIVER",  msg_color='green')
     yield navigator.mission_params["detect_deliver_shape"].set(shape)

--- a/mission_control/navigator_missions/nav_missions/identify_dock.py
+++ b/mission_control/navigator_missions/nav_missions/identify_dock.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+from __future__ import division
+import txros
+import std_srvs.srv
+import numpy as np
+import tf
+import tf.transformations as trns
+from geometry_msgs.msg import Point
+from std_srvs.srv import SetBool, SetBoolRequest
+from twisted.internet import defer
+from visualization_msgs.msg import Marker,MarkerArray
+import navigator_tools
+from navigator_tools import fprint, MissingPerceptionObject
+from navigator_msgs.srv import GetDockBays, GetDockBaysRequest
+from navigator_msgs.srv import CameraToLidarTransform,CameraToLidarTransformRequest
+
+print_good = lambda message: fprint(message, title="IDENTIFY DOCK",  msg_color='green')
+print_bad  = lambda message: fprint(message, title="IDENTIFY DOCK",  msg_color='yellow')
+
+class IdentifyDockMission:
+    CIRCLE_RADIUS      = 16  # Radius of circle in dock circle pattern
+    BAY_SEARCH_TIMEOUT = 80  # Seconds to circle dock looking for bays before giving up
+    LOOK_AT_DISTANCE   = 10  # Distance in front of bay to move to to look at shape
+    LOOK_SHAPE_TIMEOUT = 10  # Time to look at bay with cam to see symbol
+    DOCK_DISTANCE      = 3   # Distance in front of bay point to dock to
+    DOCK_SLEEP_TIME    = 5   # Time to wait after docking before undocking aka show off time
+    WAYPOINT_NAME      = "dock"
+    TIMEOUT_CIRCLE_VISION_ONLY    = 75
+
+    def __init__(self, navigator):
+        self.navigator = navigator
+
+    def _init_default(self):
+        self.ogrid_activation_client = self.navigator.nh.get_service_client('/identify_dock/active', SetBool)
+        self.get_bays = self.navigator.nh.get_service_client('/identify_dock/get_bays', GetDockBays)
+        self.bays_res = None
+        self.bays_symbols = (None, None, None)
+        self.docked = (False, False)
+
+    def start_ogrid(self):
+        return self.ogrid_activation_client(SetBoolRequest(data=True))
+
+    def stop_ogrid(self):
+        return self.ogrid_listen_client(SetBoolRequest(data=False))
+
+    @txros.util.cancellableInlineCallbacks
+    def get_target_bays(self):
+        bay_1_color = yield self.navigator.mission_params["dock_color_1"].get()
+        bay_1_shape = yield self.navigator.mission_params["dock_shape_1"].get()
+        bay_2_color = yield self.navigator.mission_params["dock_color_2"].get()
+        bay_2_shape = yield self.navigator.mission_params["dock_shape_2"].get()
+        self.bay_1 = (bay_1_shape, bay_1_color)
+        self.bay_2 = (bay_2_shape, bay_2_color)
+        print_good("Docking in Bay (Shape={}, Color={}) then (Shape={}, Color={})".format(bay_1_shape, bay_1_color, bay_2_shape, bay_2_color))
+
+    @txros.util.cancellableInlineCallbacks
+    def get_waypoint(self):
+        res = yield self.navigator.database_query(self.WAYPOINT_NAME)
+        self.dock_pose = navigator_tools.rosmsg_to_numpy(res.objects[0].position)
+
+    @txros.util.cancellableInlineCallbacks
+    def search_bays(self):
+        res = yield self.get_bays(GetDockBaysRequest())
+        if not res.success:
+            print_bad("Bays Not found Error={}".format(res.error))
+        else:
+            self.bays_res = res
+            self.bay_poses = (navigator_tools.rosmsg_to_numpy(res.bays[0]),
+              navigator_tools.rosmsg_to_numpy(res.bays[1]),
+              navigator_tools.rosmsg_to_numpy(res.bays[2]))
+            self.bay_normal = navigator_tools.rosmsg_to_numpy(res.normal)
+        defer.returnValue(res.success)
+
+    @txros.util.cancellableInlineCallbacks
+    def circle_dock(self):
+        '''
+        Circle the dock until the bays are identified by the perception service
+        '''
+        print_good("Starting circle search")
+        pattern = self.navigator.move.d_circle_point(self.dock_pose, radius=self.CIRCLE_RADIUS)
+        yield next(pattern).go()
+        searcher = self.navigator.search(search_pattern=pattern, looker=self.search_bays)
+        yield searcher.start_search(timeout=self.BAY_SEARCH_TIMEOUT, move_type="skid", loop=True)
+        if self.bays_res == None:
+            raise Exception("Bays not found after circling")
+        print_good("Ended circle search")
+
+    @txros.util.cancellableInlineCallbacks
+    def search_shape(self):
+        res = self.navigator.vision_proxies["get_shape_front"].get_response(Shape="ANY", Color="ANY")
+        if res.found:
+            self.bays_symbols[self.check_index] = res
+        defer.returnValue(res.found)
+
+    @txros.util.cancellableInlineCallbacks
+    def dock_in_bay(self, index):
+        move_front = self.navigator.move.set_position(self.bay_poses[i] + self.bay_normal * self.LOOK_AT_DISTANCE).look_at(self.bay_poses[i])
+        move_in    = self.navigator.move.set_position(self.bay_poses[i] + self.bay_normal *  self.DOCK_DISTANCE).look_at(self.bay_poses[i])
+        yield move_front.go()
+        yield move_in.go()
+        yield self.navigator.nh.sleep(DOCK_SLEEP_TIME)
+        yield move_front.go()
+        
+    @txros.util.cancellableInlineCallbacks
+    def dock_if_identified(self):
+        '''
+        See if a bay was identified with desired symbol, dock if so
+        '''
+        for i, shape_res in enumerate(self.bays_symbols):
+            if not shape_res == None:
+                if self.correct_shape(self.bay_1, (shape_res.Shape, shape_res.Color)) and (not self.docked[0]):
+                    print_good("Bay {index} (Shape={res.Shape}, Color={res.Color}) has first search bay, docking".format(index=i, res=shape_res))
+                    yield self.dock_in_bay(i)
+                    self.docked[0] = True
+                elif self.correct_shape(self.bay_2, (shape_res.Shape, shape_res.Color)) and (not self.docked[1]) and (self.docked[0]):
+                    print_good("Bay {index} (Shape={res.Shape}, Color={res.Color}) has seconds search bay, docking".format(index=i, res=shape_res))
+                    yield self.dock_in_bay(i)
+                    self.docked[1] = True
+                else:
+                    print_bad("Bay {index} (Shape={res.Shape}, Color={res.Color}) does not match a search shape".format(index=i, res=shape_res))
+                  
+            
+
+    def correct_shape(self, (desired_shape, desired_color), (test_shape, test_color) ):
+        return (desired_color == "ANY" or desired_color == test_color) and (desired_shape == "ANY" or desired_shape == test_shape)
+
+    @txros.util.cancellableInlineCallbacks
+    def check_bays(self):
+        '''
+        Go in front of each bay and look at the symbols present
+        '''
+        for i, pose in enumerate(self.bay_poses):
+            self.check_index = i
+            move = self.navigator.move.set_position(pose + self.bay_normal * self.LOOK_AT_DISTANCE).look_at(pose)
+            yield move.go()
+            searcher = self.navigator.search(looker=self.search_shape)
+            yield searcher.start_search(timeout=self.LOOK_SHAPE_TIMEOUT)
+            yield self.dock_if_identified()
+
+    @txros.util.cancellableInlineCallbacks
+    def find_and_dock(self):
+        self._init_default()
+        yield self.navigator.vision_proxies["get_shape_front"].start()
+        yield self.get_target_bays()
+        yield self.get_waypoint()
+        yield self.start_ogrid()
+        yield self.circle_dock()
+        yield self.stop_ogrid()
+        yield self.navigator.vision_proxies["get_shape_front"].stop()
+
+
+
+    '''
+    Alternative method using vision only like detect deliver, no lidar analysis perception
+    '''
+    def _init_vision_only(self):
+        self.ogrid_activation_client = self.navigator.nh.get_service_client('/identify_dock/active', SetBool)
+        self.cameraLidarTransformer = self.navigator.nh.get_service_client("/camera_to_lidar/stereo_right_cam", CameraToLidarTransform)
+        self.identified_shapes = {}
+
+    def update_shape(self, shape_res, normal_res, tf):
+       self.identified_shapes[(shape_res.Shape, shape_res.Color)] = self.get_shape_pos(normal_res, tf)
+
+    def done_circling(self):
+        print_good("CURRENT IDENTIFIED BAYS: {}".format(self.identifed_shapes))
+        for shape_color, point_normal in self.identified_shapes.iteritems():
+            if self.correct_shape(self.bay_1, shape_color):
+              for shape_color2, point_normal in self.identified_shapes.iteritems():
+                  if self.correct_shape(self.bay_2, shape_color2):
+                      return True
+        return False
+
+    @txros.util.cancellableInlineCallbacks
+    def search_shape_vision_only(self):
+        shapes = yield self.navigator.vision_proxies["get_shape_front"].get_response(Shape="ANY", Color="ANY")
+        if shapes.found:
+            for shape in shapes.shapes.list:
+                normal_res = yield self.get_normal(shape)
+                if normal_res.success:
+                    enu_cam_tf = yield self.navigator.tf_listener.get_transform('/enu', '/'+shape.header.frame_id, shape.header.stamp)
+                    self.update_shape(shape, normal_res, enu_cam_tf)
+                    if (self.done_circling()):
+                        defer.returnValue(True)
+                else:
+                      print_bad("NORMAL ERROR: {}".format(normal_res.error))
+        else:
+            print_bad("SHAPES ERROR: ".format(shapes.error))
+        defer.returnValue(False)
+
+    def _bounding_rect(self,points):
+        np_points = map(navigator_tools.point_to_numpy, points)
+        xy_max = np.max(np_points, axis=0)
+        xy_min = np.min(np_points, axis=0)
+        return np.append(xy_max, xy_min)
+
+    @txros.util.cancellableInlineCallbacks
+    def circle_dock_vision_only(self):
+        print_good("Starting circle search (vision only)")
+        pattern = self.navigator.move.d_circle_point(self.dock_pose, radius=self.CIRCLE_RADIUS)
+        searcher = self.navigator.search(search_pattern=pattern, looker=self.search_shape_vision_only)
+        yield searcher.start_search(timeout=self.TIMEOUT_CIRCLE_VISION_ONLY, spotings_req=1, move_type="skid")
+        print_good("Ended circle search")
+
+    def normal_is_sane(self, vector3):
+         return abs(navigator_tools.rosmsg_to_numpy(vector3)[1]) < 0.2
+
+    @txros.util.cancellableInlineCallbacks
+    def get_normal(self, shape):
+        req = CameraToLidarTransformRequest()
+        req.header = shape.header
+        req.point = Point()
+        req.point.x = shape.CenterX
+        req.point.y = shape.CenterY
+        rect = self._bounding_rect(shape.points)
+        req.tolerance = int(min(rect[0]-rect[3],rect[1]-rect[4])/2.0)
+        normal_res = yield self.cameraLidarTransformer(req)
+        if not self.normal_is_sane(normal_res.normal):
+            normal_res.success = False
+            normal_res.error = "UNREASONABLE NORMAL"
+        defer.returnValue(normal_res)
+
+    def get_shape_pos(self, normal_res, enu_cam_tf):
+        enunormal = enu_cam_tf.transform_vector(navigator_tools.rosmsg_to_numpy(normal_res.normal))
+        enupoint = enu_cam_tf.transform_point(navigator_tools.rosmsg_to_numpy(normal_res.closest))
+        return (enupoint, enunormal)
+
+    @txros.util.cancellableInlineCallbacks
+    def dock_vision_only(self):
+        bay_1_shape = None
+        bay_2_shape = None
+        incorrect_shapes = []
+        for shape_color, point_normal in self.identified_shapes.iteritems():
+            if   self.correct_shape(self.bay_1, shape_color):
+                bay_1_shape = point_normal
+            elif self.correct_shape(self.bay_2, shape_color):
+                bay_2_shape = point_normal
+            else:
+                incorrect_shapes.append(point_normal)
+        if bay_1_shape == None:
+            if len(self.incorrect_shapes) >= 1:
+                print_bad("First bay not found, going in random bay")
+                yield self.dock_in_bay_vision_only(incorrect_shapes[0])
+                del incorrect_shapes[0]
+            else:
+                print_bad("First bay not found and no other bays found, moving on to second")
+        else:
+            print_good("Docking in first desired bay")
+            yield self.dock_in_bay_vision_only(bay_1_shape)
+
+        if bay_2_shape == None:
+            if len(self.incorrect_shapes) >= 1:
+                print_bad("Second bay not found, going in random bay")
+                yield self.dock_in_bay_vision_only(incorrect_shapes[0])
+                del incorrect_shapes[0]
+            else:
+                print_bad("Second bay not found and no other bays found")
+        else:
+            print_good("Docking in second desired bay")
+            yield self.dock_in_bay_vision_only(bay_2_shape)
+
+    @txros.util.cancellableInlineCallbacks
+    def dock_in_bay_vision_only(self, (shapepoint, shapenormal)):
+        move_front = self.navigator.move.set_position(shapepoint + shapenormal * self.LOOK_AT_DISTANCE).look_at(shapepoint)
+        move_in    = self.navigator.move.set_position(shapepoint + shapenormal *  self.DOCK_DISTANCE).look_at(shapepoint)
+        yield move_front.go()
+        #  yield self.start_ogrid()
+        yield move_in.go()
+        yield self.navigator.nh.sleep(self.DOCK_SLEEP_TIME)
+        yield move_front.go()
+        #  yield self.stop_ogrid()
+
+    @txros.util.cancellableInlineCallbacks
+    def find_and_dock_vision_only(self):
+        self._init_vision_only()
+        yield self.navigator.vision_proxies["get_shape_front"].start()
+        yield self.get_target_bays()
+        yield self.get_waypoint()
+        yield self.circle_dock_vision_only()
+        yield self.dock_vision_only()
+        yield self.navigator.vision_proxies["get_shape_front"].stop()
+
+@txros.util.cancellableInlineCallbacks
+def setup_mission(navigator):
+    bay_1_color = "RED"
+    bay_1_shape = "CIRCLE"
+    bay_2_color = "RED"
+    bay_2_shape = "CIRCLE"
+    yield navigator.mission_params["dock_shape_2"].set(bay_2_shape)
+    yield navigator.mission_params["dock_shape_1"].set(bay_1_shape)
+    yield navigator.mission_params["dock_color_1"].set(bay_1_color)
+    yield navigator.mission_params["dock_color_2"].set(bay_2_color)
+
+@txros.util.cancellableInlineCallbacks
+def main(navigator, **kwargs):
+    yield setup_mission(navigator)
+    print_good("STARTING MISSION")
+    mission = IdentifyDockMission(navigator)
+    yield mission.find_and_dock_vision_only()
+    print_bad("ENDING MISSION")
+

--- a/mission_control/navigator_missions/nav_missions/identify_dock.py
+++ b/mission_control/navigator_missions/nav_missions/identify_dock.py
@@ -269,9 +269,9 @@ class IdentifyDockMission:
         move_front = self.navigator.move.set_position(shapepoint + shapenormal * self.LOOK_AT_DISTANCE).look_at(shapepoint)
         move_in    = self.navigator.move.set_position(shapepoint + shapenormal *  self.DOCK_DISTANCE).look_at(shapepoint)
         yield move_front.go(move_type='skid')
-        yield move_in.go(move_type='skid', speed_factor=[0.5,0.5,0.5])
+        yield move_in.go(move_type='skid', speed_factor=[0.5,0.5,0.5], blind=True)
         yield self.navigator.nh.sleep(self.DOCK_SLEEP_TIME)
-        yield move_front.go(move_type='skid', speed_factor=[0.5,0.5,0.5])
+        yield move_front.go(move_type='skid', speed_factor=[0.5,0.5,0.5], blind=True)
 
     @txros.util.cancellableInlineCallbacks
     def find_and_dock_vision_only(self):

--- a/mission_control/navigator_missions/nav_missions/pinger.py
+++ b/mission_control/navigator_missions/nav_missions/pinger.py
@@ -18,6 +18,8 @@ class PingerMission:
     GATE_CROSS_METERS = 10
     FREQ = 35000
     LISTEN_TIME = 15
+    MAX_CIRCLE_BUOY_ERROR = 30
+    CIRCLE_RADIUS = 5
 
     def __init__(self, navigator):
         self.navigator = navigator
@@ -27,7 +29,8 @@ class PingerMission:
         self.negate = False
         self.marker_pub = self.navigator.nh.advertise("/pinger/debug_marker",MarkerArray)
         self.markers = MarkerArray()
-        self.last_id = 0;
+        self.last_id = 0
+        self.circle_totem = None
 
     def reset_freq(self):
         return self.reset_client(SetFrequencyRequest(frequency=self.FREQ))
@@ -151,6 +154,11 @@ class PingerMission:
 
             sorted_circle = sorted(totems.objects, key=lambda t: abs(np.linalg.norm(estimated_circle_buoy - navigator_tools.rosmsg_to_numpy(t.position)[:2])))
             self.new_marker(position=navigator_tools.rosmsg_to_numpy(sorted_circle[0].position), color=(1,1,1), time=cur_time)
+            if np.linalg.norm(navigator_tools.rosmsg_to_numpy(sorted_circle[0].position)[:2] - estimated_circle_buoy) < self.MAX_CIRCLE_BUOY_ERROR:
+                self.circle_totem = navigator_tools.rosmsg_to_numpy(sorted_circle[0].position)
+                fprint("PINGER: found buoy to circle at {}".format(self.circle_totem), msg_color='green')
+            else:
+                fprint("PINGER: circle buoy is too far from where it should be", msg_color='red')
 
             if sorted_3[0].color.r > 0.9:
                 color_3 = "RED"
@@ -169,7 +177,7 @@ class PingerMission:
                 self.new_marker(position=navigator_tools.rosmsg_to_numpy(sorted_1[0].position), color=(0,1,0), time=cur_time)
             else:
                 color_1 = "UNKNOWN"
-                yself.new_marker(position=navigator_tools.rosmsg_to_numpy(sorted_1[0].position), color=(1,1,1), time=cur_time)
+                self.new_marker(position=navigator_tools.rosmsg_to_numpy(sorted_1[0].position), color=(1,1,1), time=cur_time)
 
             if int(self.gate_index) == 0:
                 if color_1 == "RED":
@@ -209,7 +217,10 @@ class PingerMission:
 
     @txros.util.cancellableInlineCallbacks
     def circle_buoy(self):
-         pass
+        if self.circle_totem != None:
+            pattern = self.navigator.move.d_circle_point(self.circle_totem, radius=self.CIRCLE_RADIUS, direction='cw')
+            for pose in pattern:
+                yield pose.go(move_type="skid")
 
     def get_gate_perp(self):
         """Calculate a perpendicular to the line formed by the three gates"""
@@ -246,6 +257,7 @@ class PingerMission:
         fprint("PINGER: Going through gate", msg_color='green') 
         yield self.go_thru_gate()
         yield self.set_active_pinger()
+        yield self.circle_buoy()
         #  yield self.circle_buoy()
         fprint("PINGER: Ended Pinger Mission", msg_color='green') 
 

--- a/mission_control/navigator_missions/nav_missions/pinger.py
+++ b/mission_control/navigator_missions/nav_missions/pinger.py
@@ -221,6 +221,8 @@ class PingerMission:
             pattern = self.navigator.move.d_circle_point(self.circle_totem, radius=self.CIRCLE_RADIUS, direction='cw')
             for pose in pattern:
                 yield pose.go(move_type="skid")
+            for p in reversed(self.gate_thru_points):
+                yield self.navigator.move.set_position(p).go(initial_plan_time=5, move_type="skid")
 
     def get_gate_perp(self):
         """Calculate a perpendicular to the line formed by the three gates"""

--- a/mission_control/navigator_missions/nav_missions/pinger.py
+++ b/mission_control/navigator_missions/nav_missions/pinger.py
@@ -14,12 +14,12 @@ import rospy
 ___author___ = "Kevin Allen"
 
 class PingerMission:
-    OBSERVE_DISTANCE_METERS = 12
-    GATE_CROSS_METERS = 10
+    OBSERVE_DISTANCE_METERS = 5
+    GATE_CROSS_METERS = 5
     FREQ = 35000
-    LISTEN_TIME = 15
+    LISTEN_TIME = 10
     MAX_CIRCLE_BUOY_ERROR = 30
-    CIRCLE_RADIUS = 5
+    CIRCLE_RADIUS = 8
 
     def __init__(self, navigator):
         self.navigator = navigator
@@ -218,11 +218,13 @@ class PingerMission:
     @txros.util.cancellableInlineCallbacks
     def circle_buoy(self):
         if self.circle_totem != None:
-            pattern = self.navigator.move.d_circle_point(self.circle_totem, radius=self.CIRCLE_RADIUS, direction='cw')
-            for pose in pattern:
-                yield pose.go(move_type="skid")
-            for p in reversed(self.gate_thru_points):
-                yield self.navigator.move.set_position(p).go(initial_plan_time=5, move_type="skid")
+            #Circle around totem
+            yield self.navigator.move.look_at(self.circle_totem).set_position(self.circle_totem).backward(8).yaw_left(90, unit='deg').go()
+            yield self.navigator.move.circle_point(self.circle_totem).go()
+
+            (first, last) = reversed(self.gate_thru_points)
+            yield self.navigator.move.set_position(first).look_at(last).go(initial_plan_time=5, move_type="drive")
+            yield self.navigator.move.set_position(last).go(initial_plan_time=5, move_type="drive")
 
     def get_gate_perp(self):
         """Calculate a perpendicular to the line formed by the three gates"""

--- a/mission_control/navigator_missions/navigator_singleton/navigator.py
+++ b/mission_control/navigator_missions/navigator_singleton/navigator.py
@@ -350,8 +350,7 @@ class MissionParam(object):
 
 
 class Searcher(object):
-
-    def __init__(self, nav, search_pattern, looker=None, vision_proxy="test", **kwargs):
+    def __init__(self, nav, search_pattern=None, looker=None, vision_proxy="test", **kwargs):
         self.nav = nav
         self.looker = looker
         if looker == None:
@@ -363,6 +362,7 @@ class Searcher(object):
         self.object_found = False
         self.pattern_done = False
         self.response = None
+        print "dfdf"
 
     def catch_error(self, failure):
         if failure.check(defer.CancelledError):
@@ -376,7 +376,8 @@ class Searcher(object):
     def start_search(self, timeout=120, loop=True, spotings_req=2, **kwargs):
         fprint("Starting.", title="SEARCHER")
         looker = self._run_look(spotings_req).addErrback(self.catch_error)
-        finder = self._run_search_pattern(loop, **kwargs).addErrback(self.catch_error)
+        if self.search_pattern != None:
+            finder = self._run_search_pattern(loop, **kwargs).addErrback(self.catch_error)
 
         start_pose = self.nav.move.forward(0)
         start_time = self.nav.nh.get_time()

--- a/mission_control/navigator_missions/navigator_singleton/vision_services.yaml
+++ b/mission_control/navigator_missions/navigator_singleton/vision_services.yaml
@@ -11,6 +11,11 @@ get_shape:
   type: GetDockShapes
   args: {'Shape': "CIRCLE", 'Color':"RED"}
 
+get_shape_front:
+  topic: /vision/get_shapes_front
+  type: GetDockShapes
+  args: {'Shape': "CIRCLE", 'Color':"RED"}
+
 scan_the_code_activate:
   topic: /vision/scan_the_code_activate
   type: ScanTheCodeMission

--- a/mission_systems/shooter/nodes/ShooterControl.py
+++ b/mission_systems/shooter/nodes/ShooterControl.py
@@ -43,7 +43,7 @@ class ShooterControl:
         self.status_pub = rospy.Publisher('/shooter/status', String, queue_size=5)
         self.manual_used = False
         self.killed = False
-        self.kill_listener = AlarmListener("kill", self.update_kill_status)
+        #self.kill_listener = AlarmListener("/kill", self.update_kill_status)
 
     def update_kill_status(self, alarm):
         '''

--- a/perception/navigator_vision/nodes/camera_to_lidar/CameraLidarTransformer.hpp
+++ b/perception/navigator_vision/nodes/camera_to_lidar/CameraLidarTransformer.hpp
@@ -54,6 +54,7 @@ class CameraLidarTransformer
     void cameraInfoCallback(const sensor_msgs::CameraInfo info);
     void drawPoint(cv::Mat& mat, cv::Point2d& p, cv::Scalar color=cv::Scalar(0, 0, 255));
     bool transformServiceCallback(navigator_msgs::CameraToLidarTransform::Request &req,navigator_msgs::CameraToLidarTransform::Response &res);
+    static ros::Duration MAX_TIME_ERR;
     #ifdef DO_ROS_DEBUG
     ros::Publisher pubMarkers;
     image_transport::ImageTransport image_transport;

--- a/perception/navigator_vision/nodes/shape_identification/ShapeTracker.cpp
+++ b/perception/navigator_vision/nodes/shape_identification/ShapeTracker.cpp
@@ -30,7 +30,10 @@ void ShapeTracker::addShapes(navigator_msgs::DockShapes& newShapes)
  {
    addShape(shape);
  }
- shapes.erase(std::remove_if(shapes.begin(), shapes.end(), [] (TrackedShape& s) {return s.isStale();}),shapes.end());
+ shapes.erase(std::remove_if(shapes.begin(), shapes.end(), [] (TrackedShape& s) {
+   //  if (s.isStale()) printf("Shape is stale, removing\n");
+   return s.isStale();
+ }),shapes.end());
  // ~printf("Shapes size %d\n",shapes.size());
  navigator_msgs::DockShapes found_shapes;
  for (auto &tracked : shapes)

--- a/perception/navigator_vision/nodes/shape_identification/TrackedShape.cpp
+++ b/perception/navigator_vision/nodes/shape_identification/TrackedShape.cpp
@@ -19,7 +19,9 @@ void TrackedShape::init(ros::NodeHandle& nh)
   nh.param<double>("tracking/max_distance_gap",MAX_DISTANCE,15);
   double seconds;
   nh.param<double>("tracking/max_seen_gap_seconds", seconds, 0.5);
-  MAX_TIME_GAP = ros::Duration(0, seconds * 1E9);
+  double partial_secs = fmod(seconds, 1);
+  seconds -= partial_secs;
+  MAX_TIME_GAP = ros::Duration(seconds, partial_secs * 1E9);
 }
 double TrackedShape::centerDistance(navigator_msgs::DockShape& a, navigator_msgs::DockShape& b)
 {
@@ -31,12 +33,12 @@ bool TrackedShape::update(navigator_msgs::DockShape& s)
   double distance = centerDistance(latest,s);
   if (distance > MAX_DISTANCE)
   {
-    // ~printf(" %s %s distance too big to %s %s DISTANCE = %f \n",latest.Color.c_str(),latest.Shape.c_str(),s.Color.c_str(),s.Shape.c_str(),distance);
+    //  printf(" %s %s distance too big to %s %s DISTANCE = %f \n",latest.Color.c_str(),latest.Shape.c_str(),s.Color.c_str(),s.Shape.c_str(),distance);
     return false;
   } 
   if (tooOld(s))
   {
-    // ~printf(" %s %s too old from %s %s\n",latest.Color.c_str(),latest.Shape.c_str(),s.Color.c_str(),s.Shape.c_str());
+    //  printf(" %s %s too old from %s %s\n",latest.Color.c_str(),latest.Shape.c_str(),s.Color.c_str(),s.Shape.c_str());
     return false;
   }
   if (latest.Color != s.Color)
@@ -69,6 +71,7 @@ bool TrackedShape::isStale()
 }
 bool TrackedShape::isReady()
 {
+  //  printf("Count=%d, TooOld=%d\n", count, isStale());
   return count >= MIN_COUNT && !isStale();
 }
 navigator_msgs::DockShape TrackedShape::get()

--- a/perception/navigator_vision/nodes/shape_identification/main.cpp
+++ b/perception/navigator_vision/nodes/shape_identification/main.cpp
@@ -45,7 +45,9 @@ class ShooterVision {
     vision->init();
     nh_.param<std::string>("symbol_camera", camera_topic,
                            "/right/right/image_raw");
-    runService = nh_.advertiseService("/vision/get_shapes/switch", &ShooterVision::runCallback, this);
+    std::string get_shapes_topic;
+    nh_.param<std::string>("get_shapes_topic",get_shapes_topic,"get_shapes");
+    runService = nh_.advertiseService(get_shapes_topic+"/switch", &ShooterVision::runCallback, this);
     roiService = nh_.advertiseService("setROI",
                                       &ShooterVision::roiServiceCallback, this);
     //#ifdef DO_DEBUG

--- a/simulation/navigator_gazebo/nodes/sim_hydrophones.py
+++ b/simulation/navigator_gazebo/nodes/sim_hydrophones.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import rospy
+from std_srvs.srv import SetBool, SetBoolResponse
+from navigator_msgs.srv import FindPinger, FindPingerResponse, SetFrequency, SetFrequencyResponse
+
+def find_pinger_cb(req):
+  #hardcoded for one of the gates
+  res = FindPingerResponse()
+  res.pinger_position.x = 15.0719184875
+  res.pinger_position.y =-15.6615581512
+  res.pinger_position.z = 0
+  return res
+
+def default_cb(req):
+  return {}
+
+if __name__ == '__main__':
+    rospy.init_node('hydrophones_sim')
+    rospy.Service('/hydrophones/find_pinger', FindPinger, find_pinger_cb)
+    rospy.Service('/hydrophones/set_freq', SetFrequency, default_cb)
+    rospy.Service('/hydrophones/set_listen', SetBool, default_cb)
+    rospy.spin()

--- a/utils/navigator_msgs/CMakeLists.txt
+++ b/utils/navigator_msgs/CMakeLists.txt
@@ -50,6 +50,7 @@ add_service_files(
   ColorRequest.srv
   FindPinger.srv
   SetFrequency.srv
+  GetDockBays.srv
 )
 
 add_action_files(

--- a/utils/navigator_msgs/srv/GetDockBays.srv
+++ b/utils/navigator_msgs/srv/GetDockBays.srv
@@ -1,0 +1,5 @@
+---
+geometry_msgs/Point[3] bays   #The positions in ENU frame of the center of the three bays 0=left, 1=center, 2=right
+geometry_msgs/Vector3  normal #Vector or normal pointing away from plane of dock back
+bool success                  #False if an error occured getting dock bays
+string error                  #Descripion of error if success=false


### PR DESCRIPTION
- Shooter does not listen to kill (for real this time)
- Pinger now circles totem 30 meters away, and move much more smoothly with drive mode and smooth circles
- Detect Deliver smooth circles until finding one shape, then uses that normal to look at the other shapes if necessary
- Add identify and dock mission. For now, just circles around fake "Dock" object looking for correct shapes, then aligns based on the normals to those shapes (like detect deliver)
- And hydrophone service faker for sim
- Identify and dock has skeleton code for working with the more advanced options being developed by @RustyBamboo and @whispercoros to publish a special dock mission ogrid and identify the dock bays with ogrid/lidar rather than vision.
- Shapes perception and camera to lidar normal had been made more reliable by fixing two major bugs
- Bag.launch launches classification stuff properly using launch file
