### PR TITLE
WRENCH: default to no wrench selected for safety

### DIFF
--- a/mission_control/navigator_launch/launch/gnc.launch
+++ b/mission_control/navigator_launch/launch/gnc.launch
@@ -17,7 +17,7 @@
 
 
     <node name="wrench_arbiter" ns="/wrench" pkg="topic_tools" type="mux"
-          args="cmd autonomous rc emergency keyboard" >
+          args="cmd cmd autonomous rc emergency keyboard" >
         <remap from="mux" to="/wrench" />
     </node>
 

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -18,6 +18,25 @@ alias sshnav="ssh navigator@${HOSTNAMES[1]} -Y"
 alias navm="rosrun navigator_missions run_mission"
 alias navc="rosrun navigator_missions move_command"
 
+# Wrench
+_nwrench_complete()
+{
+	local WRENCH
+  local WRENCHES
+  WRENCHES=( rc autonomous keyboard emergency )
+	for WRENCH in "${WRENCHES[@]}"; do
+		# Skip any entry that does not match the string to complete
+		if [[ -z "$2" || ! -z "$(echo ${WRENCH:0:${#2}} | grep $2)" ]]; then
+				COMPREPLY+=( "$WRENCH" )
+		fi
+	done
+}
+nwrench()
+{
+    rosservice call /wrench/select "topic: '$1'"
+}
+complete -F _nwrench_complete nwrench
+
 # Alarms
 alias nhold="rosrun ros_alarms raise station-hold"
 


### PR DESCRIPTION
I was thinking about if we should start in autonomous or rc mode by default. I think the best option is to start with no wrench selected, we we have to explicitly set to rc or autonomous before moving. Also added a alias nwrench for selecting wrench, with tab completion (booya!)