### PR TITLE
LAUNCH: remove path planner duplicate in simulation.launch

### DIFF
--- a/mission_control/navigator_launch/launch/gnc.launch
+++ b/mission_control/navigator_launch/launch/gnc.launch
@@ -1,4 +1,6 @@
 <launch>
+    <arg name="gps" default="True" />
+
     <node pkg="navigator_thrust_mapper" type="thrust_mapper.py" name="thrust_mapper">
     <!-- Parameters used to set the thruster locations and angles relative to the center of gravity of the boat -->
         <rosparam param="thruster_BL_cog">[-1.9304, 1.016]</rosparam>
@@ -42,5 +44,7 @@
     <node name="bounds_server" pkg="navigator_tools" type="bounds.py"/>
     <node name="rviz_repub" pkg="mil_tools" type="rviz_waypoint.py"/>
     <node name="set_bounds" pkg="dynamic_reconfigure" type="dynparam" args="load /bounds_server $(find navigator_tools)/cfg/wauberg.yaml -t 10" />
-    <include file="$(find navigator_launch)/launch/subsystems/gps.launch" />
+
+    <!-- Connect to GPS device -->
+    <include if="$(arg gps)" file="$(find navigator_launch)/launch/subsystems/gps.launch" />
 </launch>

--- a/mission_control/navigator_launch/launch/simulation.launch
+++ b/mission_control/navigator_launch/launch/simulation.launch
@@ -16,8 +16,9 @@
     </node>
 
     <include file="$(find navigator_launch)/launch/subsystems/alarms.launch"/>
-    <include file="$(find navigator_launch)/launch/subsystems/path_planner.launch"/>
-    <include file="$(find navigator_launch)/launch/gnc.launch"/>
+    <include file="$(find navigator_launch)/launch/gnc.launch">
+      <arg name="gps" value="False" />
+    </include>
     <!--node name="gnc_delayed_start" pkg="navigator_gazebo" type="delayed_start.sh"/-->
 
 
@@ -27,12 +28,7 @@
         <arg name="sandbox" value="$(arg sandbox)"/>
     </include>
 
-    <!-- This all is launched on boot on the boat -->
-    <node name="coordinate_converter" pkg="navigator_tools" type="coordinate_conversion_server.py"/>
-    <node name="rviz_repub" pkg="mil_tools" type="rviz_waypoint.py"/>
-    <node name="bounds_server" pkg="navigator_tools" type="bounds.py"/>
-    <node name="set_bounds" pkg="dynamic_reconfigure" type="dynparam" args="load /bounds_server $(find navigator_tools)/cfg/sim.yaml -t 10" />
-
+    <!-- Connect to joystick if plugged in, otherwise spam annoying red text ;) -->
     <node pkg="joy" type="joy_node" name="joy_node">
         <param name="dev" type="string" value="/dev/input/by-id/usb-045e_0291-joystick" />
         <param name="deadzone" value="0.12" />


### PR DESCRIPTION
* it is now already included in gnc.launch

Didn't see this before I merged #251. My B!