### PR TITLE
KILL BOARD: replace remote constant with heartbeats and button constants

### DIFF
--- a/hardware_drivers/navigator_kill_board/navigator_kill_board/constants.py
+++ b/hardware_drivers/navigator_kill_board/navigator_kill_board/constants.py
@@ -18,7 +18,7 @@ The computer can also command a kill (for example, if ROS notices a criticaly lo
 by sending the COMPUTER.KILL.REQUEST and undone with COMPUTER.CLEAR.REQUEST
 '''
 constants = {
-    'TIMEOUT_SECONDS': 8.0,  # How often board must be pinged to not set REMOTE to True
+    'TIMEOUT_SECONDS': 8.0,  # How often board must be pinged to not set HEARTBERAT_REMOTE True
                              # Note: not official documented, this is just a guess
     'RESPONSE_FALSE': '\x00',  # True status for synchronous requests of individual addresses
     'RESPONSE_TRUE': '\x01',   # False status for synchronous requests of individual addresses
@@ -29,7 +29,8 @@ constants = {
     },
 
     'KILLS': ['OVERALL', 'BUTTON_FRONT_PORT', 'BUTTON_AFT_PORT', 'BUTTON_FRONT_STARBOARD',\
-              'BUTTON_AFT_STARBOARD', 'REMOTE', 'COMPUTER'],
+              'BUTTON_AFT_STARBOARD', 'HEARTBEAT_COMPUTER', 'BUTTON_REMOTE',\
+              'HEARTBEAT_REMOTE', 'COMPUTER'],
     'OVERALL': {  # Should be True if any of the over are True
         'REQUEST': '\x21',
         'TRUE': '\x10',
@@ -55,10 +56,20 @@ constants = {
         'TRUE': '\x18',
         'FALSE': '\x19'
     },
-    'REMOTE': {  # Will return True if board is not pinged often enough
+    'HEARTBEAT_COMPUTER': {  # Will return True if board is not pinged by network often enough
         'REQUEST': '\x26',
         'TRUE': '\x1A',
         'FALSE': '\x1B'
+    },
+    'BUTTON_REMOTE': {
+        'REQUEST': '\x28',
+        'TRUE': '\x3A',
+        'FALSE': '\x3B'
+    },
+    'HEARTBEAT_REMOTE': {  # Will return True if board is not pinged by controller often enough
+        'REQUEST': '\x29',
+        'TRUE': '\x3C',
+        'FALSE': '\x3D'
     },
     'COMPUTER': {  # Allows board to be killed over serial (like through ROS)
         'KILL': {

--- a/hardware_drivers/navigator_kill_board/navigator_kill_board/constants.py
+++ b/hardware_drivers/navigator_kill_board/navigator_kill_board/constants.py
@@ -56,7 +56,7 @@ constants = {
         'TRUE': '\x18',
         'FALSE': '\x19'
     },
-    'HEARTBEAT_COMPUTER': {  # Will return True if board is not pinged by network often enough
+    'HEARTBEAT_COMPUTER': {  # Will return True if board is not pinged by mobo often enough
         'REQUEST': '\x26',
         'TRUE': '\x1A',
         'FALSE': '\x1B'

--- a/hardware_drivers/navigator_kill_board/navigator_kill_board/simulated_kill_board.py
+++ b/hardware_drivers/navigator_kill_board/navigator_kill_board/simulated_kill_board.py
@@ -100,7 +100,9 @@ class SimulatedKillBoard(SimulatedSerial):
             'BUTTON_FRONT_STARBOARD': False,
             'BUTTON_AFT_STARBOARD': False,
             'COMPUTER': False,
-            'REMOTE': False,
+            'HEARTBEAT_COMPUTER': False,
+            'BUTTON_REMOTE': False,
+            'HEARTBEAT_REMOTE': False,
         }
         for key in constants['KILLS']:
             if key.find('BUTTON') == 0:
@@ -121,9 +123,9 @@ class SimulatedKillBoard(SimulatedSerial):
         if self.last_ping is None:
             return
         if (rospy.Time.now() - self.last_ping).to_sec() >= constants['TIMEOUT_SECONDS']:
-            self._set_kill('REMOTE', True)
+            self._set_kill('HEARTBEAT_COMPUTER', True)
         else:
-            self._set_kill('REMOTE', False)
+            self._set_kill('HEARTBEAT_COMPUTER', False)
 
     def _set_kill(self, name, on, update=True):
         if self.memory[name] != on:


### PR DESCRIPTION
- Rename 'REMOTE' kill constant with 'HEARTBEAT_COMPUTER' constant

- Add 'BUTTON_REMOTE' and 'HEARTBEAT_REMOTE' constants to reflect changes to data sent by kill board microprocessor

- These changes don't alter the actual kill functionality, only report more accurately the source of the kill