### PR TITLE
ALARMS: wait for alarms

### DIFF
--- a/gnc/navigator_thrust_mapper/nodes/thrust_mapper.py
+++ b/gnc/navigator_thrust_mapper/nodes/thrust_mapper.py
@@ -19,6 +19,7 @@ class ThrusterMapperNode(object):
         # To track kill state so no thrust is sent when killed (kill board hardware also ensures this)
         self.kill = False
         self.kill_listener = AlarmListener('kill', self.kill_cb)
+        self.kill_listener.wait_for_server()
 
         # Start off with no wrench
         self.wrench = np.zeros(3)

--- a/hardware_drivers/navigator_kill_board/nodes/kill_board_driver.py
+++ b/hardware_drivers/navigator_kill_board/nodes/kill_board_driver.py
@@ -54,6 +54,7 @@ class KillInterface(object):
         self.request_index = -1
 
         self.hw_kill_broadcaster = AlarmBroadcaster('hw-kill')
+        self.hw_kill_broadcaster.wait_for_server()
 
         self.joy_pub = rospy.Publisher("/joy_emergency", Joy, queue_size=1)
         self.ctrl_msg_received = False
@@ -68,8 +69,10 @@ class KillInterface(object):
             self.buttons[button] = False
         self.buttons_temp = 0x0000
 
-        AlarmListener('hw-kill', self.hw_kill_alarm_cb)
-        AlarmListener('kill', self.kill_alarm_cb)
+        self._hw_kill_listener = AlarmListener('hw-kill', self.hw_kill_alarm_cb)
+        self._kill_listener = AlarmListener('kill', self.kill_alarm_cb)
+        self._hw_kill_listener.wait_for_server()
+        self._kill_listener.wait_for_server()
         rospy.Subscriber("/wrench/selected", String, self.wrench_cb)
         rospy.Subscriber("/network", Header, self.network_cb)  # Passes along network hearbeat to kill board
 

--- a/utils/navigator_battery_monitor/nodes/navigator_battery_monitor.py
+++ b/utils/navigator_battery_monitor/nodes/navigator_battery_monitor.py
@@ -42,7 +42,8 @@ class BatteryMonitor():
         self.supply_voltages = []
 
         self.hw_kill_raised = None
-        AlarmListener('hw-kill', self.hw_kill_cb)
+        self._hw_kill_listener = AlarmListener('hw-kill', self.hw_kill_cb)
+        self._hw_kill_listener.wait_for_server()
 
         # The publisher for the averaged voltage
         self.pub_voltage = rospy.Publisher(


### PR DESCRIPTION
**depends on uf-mil/ros_alarms#40**

Nodes now wait on the alarm server if it is not up, to reduce weird timing dependent things.