### PR TITLE
CAMERAS: update id on seecam

### DIFF
--- a/mission_control/navigator_launch/launch/hardware/cameras/seecam.launch
+++ b/mission_control/navigator_launch/launch/hardware/cameras/seecam.launch
@@ -1,7 +1,7 @@
 <launch>
   <group ns="camera/seecam" >
   <node pkg="usb_cam" type="usb_cam_node" name="seecam_driver" >
-    <param name="video_device" value="/dev/v4l/by-id/usb-e-con_Systems_See3CAM_CU20_220B5905-video-index0" />
+    <param name="video_device" value="/dev/v4l/by-id/usb-e-con_Systems_See3CAM_CU20_4C0B0000-video-index0" />
     <param name="camera_frame_id" value="seecam" />
     <param name="camera_info_url" value="file://$(find navigator_launch)/config/camera_calibration/seecam_220B5905.yaml" />
     <param name="pixel_format" value="uyvy" />


### PR DESCRIPTION
The seecam in the front left is now a different unit, and has a different ID