### PR TITLE
GNC: refactor thruster_map to use URDF

### DIFF
--- a/gnc/navigator_thrust_mapper/navigator_thrust_mapper/thruster_map.py
+++ b/gnc/navigator_thrust_mapper/navigator_thrust_mapper/thruster_map.py
@@ -66,7 +66,7 @@ class ThrusterMap(object):
         '''
         urdf = URDF.from_xml_string(urdf_string)
         buff = tf2_ros.Buffer()
-        listener = tf2_ros.TransformListener(buff)
+        listener = tf2_ros.TransformListener(buff)  # noqa
         names = []
         joints = []
         positions = []

--- a/gnc/navigator_thrust_mapper/navigator_thrust_mapper/thruster_map.py
+++ b/gnc/navigator_thrust_mapper/navigator_thrust_mapper/thruster_map.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 import numpy as np
 import rospy
+from urdf_parser_py.urdf import URDF
+import tf2_ros
+from tf.transformations import euler_from_quaternion
+from mil_tools import rosmsg_to_numpy
 
 
 class ThrusterMap(object):
@@ -8,9 +12,8 @@ class ThrusterMap(object):
     Helper class to map between global body forces / torques and thruster outputs, which are in a
     arbitrary effort unit. See thruster_mapper_node.py for usage example.
     '''
-    THRUSTERS = ['BL', 'BR', 'FL', 'FR']  # Order of thrusters expected in function calls
 
-    def __init__(self, positions, angles, effort_ratio, effort_limit, com=np.zeros(2)):
+    def __init__(self, names, positions, angles, effort_ratio, effort_limit, com=np.zeros(2), joints=None):
         '''
         Creates a ThurserMapper instance
         param positions: list of X Y positions for each thuster [(x, y), (x,y), ...],
@@ -32,6 +35,8 @@ class ThrusterMap(object):
           - dynamic reconfigure ???
           - implement a more interesting solver, which attempts to minimize energy output like SubjuGator
         '''
+        self.names = names
+        self.joints = joints
         self.effort_ratio = effort_ratio
         self.effort_limit = effort_limit
 
@@ -54,19 +59,53 @@ class ThrusterMap(object):
         self.thruster_matrix_inv = np.linalg.pinv(self.thruster_matrix)  # Magical numpy psuedoinverse
 
     @classmethod
-    def from_ros_params(cls, ns='~'):
+    def from_urdf(cls, urdf_string, transmission_suffix='_thruster_transmission'):
         '''
-        Construct a mapper object from ros params, see navigator_launch/thruster_mapper.launch to see format
+        Load from an URDF string. Expects each thruster to be connected a transmission ending in the specified suffix.
+        A transform between the propeller joint and base_link must be available
         '''
+        urdf = URDF.from_xml_string(urdf_string)
+        buff = tf2_ros.Buffer()
+        listener = tf2_ros.TransformListener(buff)
+        names = []
+        joints = []
         positions = []
         angles = []
-        for thruster in cls.THRUSTERS:
-            positions.append(rospy.get_param(ns + '{}/position'.format(thruster)))
-            angles.append(rospy.get_param(ns + '{}/angle'.format(thruster)))
-        effort_ratio = rospy.get_param(ns + 'effort_ratio')
-        effort_limit = rospy.get_param(ns + 'effort_limit')
-        com = np.float64(rospy.get_param(ns + 'com', default=[0.0, 0.0]))
-        return cls(positions, angles, effort_ratio, effort_limit, com=com)
+        limit = -1
+        ratio = -1
+        for transmission in urdf.transmissions:
+            find = transmission.name.find(transmission_suffix)
+            if find != -1 and find + len(transmission_suffix) == len(transmission.name):
+                if len(transmission.joints) != 1:
+                    raise Exception('Transmission {} does not have 1 joint'.format(transmission.name))
+                if len(transmission.actuators) != 1:
+                    raise Exception('Transmission {} does not have 1 actuator'.format(transmission.name))
+                t_ratio = transmission.actuators[0].mechanicalReduction
+                if ratio != -1 and ratio != t_ratio:
+                    raise Exception('Transmission {} has a different reduction ratio (not supported)'.format(t_ratio))
+                ratio = t_ratio
+                joint = None
+                for t_joint in urdf.joints:
+                    if t_joint.name == transmission.joints[0].name:
+                        joint = t_joint
+                if joint is None:
+                    rospy.logerr('Transmission joint {} not found'.format(transmission.joints[0].name))
+                try:
+                    trans = buff.lookup_transform('base_link', joint.child, rospy.Time(), rospy.Duration(10))
+                except tf2_ros.TransformException as e:
+                    raise Exception(e)
+                translation = rosmsg_to_numpy(trans.transform.translation)
+                rot = rosmsg_to_numpy(trans.transform.rotation)
+                yaw = euler_from_quaternion(rot)[2]
+                names.append(transmission.name[0:find])
+                positions.append(translation[0:2])
+                angles.append(yaw)
+                joints.append(joint.name)
+                if limit != -1 and joint.limit.effort != limit:
+                    raise Exception('Thruster {} had a different limit, cannot proceed'.format(joint.name))
+                limit = joint.limit.effort
+
+        return cls(names, positions, angles, ratio, limit, joints=joints)
 
     def thrusts_to_wrench(self, thrusts):
         '''

--- a/gnc/navigator_thrust_mapper/nodes/thrust_mapper.py
+++ b/gnc/navigator_thrust_mapper/nodes/thrust_mapper.py
@@ -5,6 +5,7 @@ from geometry_msgs.msg import WrenchStamped
 from roboteq_msgs.msg import Command
 from ros_alarms import AlarmListener
 from navigator_thrust_mapper import ThrusterMap
+from sensor_msgs.msg import JointState
 
 
 class ThrusterMapperNode(object):
@@ -14,7 +15,10 @@ class ThrusterMapperNode(object):
     '''
     def __init__(self):
         # Used for mapping wrench to individual thrusts
-        self.thruster_map = ThrusterMap.from_ros_params()
+        urdf = rospy.get_param('robot_description', default=None)
+        if urdf is None or len(urdf) == 0:
+            raise Exception('robot description not set or empty')
+        self.thruster_map = ThrusterMap.from_urdf(urdf)
 
         # To track kill state so no thrust is sent when killed (kill board hardware also ensures this)
         self.kill = False
@@ -24,11 +28,19 @@ class ThrusterMapperNode(object):
         # Start off with no wrench
         self.wrench = np.zeros(3)
 
-        # ROS setup
-        self.BL_pub = rospy.Publisher("/BL_motor/cmd", Command, queue_size=1)
-        self.BR_pub = rospy.Publisher("/BR_motor/cmd", Command, queue_size=1)
-        self.FL_pub = rospy.Publisher("/FL_motor/cmd", Command, queue_size=1)
-        self.FR_pub = rospy.Publisher("/FR_motor/cmd", Command, queue_size=1)
+        # Publisher for each thruster
+        self.publishers = [rospy.Publisher("/{}_motor/cmd".format(name), Command, queue_size=1)
+                           for name in self.thruster_map.names]
+
+        # Joint state publisher
+        # TODO(ironmig):
+        self.joint_state_pub = rospy.Publisher('/thruster_states', JointState, queue_size=1)
+        self.joint_state_msg = JointState()
+        for name in self.thruster_map.joints:
+            self.joint_state_msg.name.append(name)
+            self.joint_state_msg.position.append(0)
+            self.joint_state_msg.effort.append(0)
+
         rospy.Subscriber("/wrench/cmd", WrenchStamped, self.wrench_cb)
 
     def kill_cb(self, alarm):
@@ -47,14 +59,18 @@ class ThrusterMapperNode(object):
         Use the mapper to find the individual thrusts needed to acheive the current body wrench.
         If killed, publish 0 to all thrusters just to be safe.
         '''
-        BL, BR, FL, FR = Command(), Command(), Command(), Command()
-        if not self.kill:  # Only get thrust of not killed, otherwise publish default 0 thrust
-            BL.setpoint, BR.setpoint, FL.setpoint, FR.setpoint = self.thruster_map.wrench_to_thrusts(self.wrench)
-        self.BL_pub.publish(BL)
-        self.BR_pub.publish(BR)
-        self.FL_pub.publish(FL)
-        self.FR_pub.publish(FR)
-
+        commands = [Command() for i in range(len(self.publishers))]
+        if not self.kill:
+            thrusts = self.thruster_map.wrench_to_thrusts(self.wrench)
+            if len(thrusts) != len(self.publishers):
+                rospy.logfatal("Number of thrusts does not equal number of publishers")
+                return
+            for i in range(len(self.publishers)):
+                commands[i].setpoint = thrusts[i]
+        for i in range(len(self.publishers)):
+            self.joint_state_msg.effort[i] = commands[i].setpoint
+            self.publishers[i].publish(commands[i])
+        self.joint_state_pub.publish(self.joint_state_msg)
 
 if __name__ == "__main__":
     rospy.init_node('thrust_mapper')

--- a/mission_control/navigator_launch/launch/gnc/tf.launch
+++ b/mission_control/navigator_launch/launch/gnc/tf.launch
@@ -3,6 +3,12 @@
     <node pkg="robot_state_publisher" name="robot_state_publisher" type="robot_state_publisher">
       <param name="use_tf_static" value="false" />
     </node>
+    <node pkg="joint_state_publisher" name="joint_state_publisher" type="joint_state_publisher">
+      <rosparam>
+        source_list:
+          - /thruster_states
+      </rosparam>
+    </node>
 
     <!-- Republishes ins-frame odom in base_link frame -->
     <node pkg="nodelet" type="nodelet" name="transform_odometry" args="standalone odometry_utils/transform_odometry">

--- a/mission_control/navigator_launch/launch/gnc/thruster_mapper.launch
+++ b/mission_control/navigator_launch/launch/gnc/thruster_mapper.launch
@@ -1,24 +1,4 @@
+<?xml version="1.0"?>
 <launch>    
-    <node pkg="navigator_thrust_mapper" type="thrust_mapper.py" name="thrust_mapper">
-        <!-- Parameters used to set the thruster locations and angles relative to the center of gravity of the boat -->
-        <rosparam>
-            # Positions of each thruster in frame of navigator center of mass (which is approximated as the base_link frame)
-            # position: [x, y] offset from center of mass in meters
-            # angle: angle thruster faces in radians, with 0 being directly forward
-            BL:
-              position: [-1.9304, 1.016]
-              angle: 0.785398
-            BR:
-              position: [-1.9304, -1.016]
-              angle: -0.785398
-            FL:
-              position: [1.5748, 0.6096]
-              angle: -0.785398
-            FR:
-              position: [1.5748, -0.6096]
-              angle: 0.785398
-            effort_ratio: 1.35  # Ratio of effort / force, so effort = effort_ratio * force
-            effort_limit: 400   # Maximum effort of a thruster in either direction, effort units
-        </rosparam>
-    </node>
+    <node pkg="navigator_thrust_mapper" type="thrust_mapper.py" name="thrust_mapper" />
 </launch>

--- a/mission_control/navigator_launch/package.xml
+++ b/mission_control/navigator_launch/package.xml
@@ -49,6 +49,7 @@
   <run_depend>navigator_missions</run_depend>
   <run_depend>navigator_2dsim</run_depend>
   <run_depend>robot_state_publisher</run_depend>
+  <run_depend>joint_state_publisher</run_depend>
   <export>
   </export>
 </package>

--- a/perception/navigator_lidar_oa/CMakeLists.txt
+++ b/perception/navigator_lidar_oa/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   tf2
   navigator_msgs
+  navigator_tools
   interactive_markers
   mil_msgs
   dynamic_reconfigure

--- a/perception/navigator_lidar_oa/package.xml
+++ b/perception/navigator_lidar_oa/package.xml
@@ -13,6 +13,7 @@
   <build_depend>tf</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>navigator_tools</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>navigator_msgs</run_depend>
@@ -20,6 +21,7 @@
   <run_depend>tf</run_depend>
   <run_depend>tf2</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>navigator_tools</run_depend>
   <export>
   </export>
 </package>

--- a/simulation/navigator_gazebo/urdf/thruster.xacro
+++ b/simulation/navigator_gazebo/urdf/thruster.xacro
@@ -68,5 +68,17 @@
       <limit effort="400" velocity="100" />
       <dynamics friction="100" damping="0.3" />
     </joint>
+
+    <transmission name="${name}_thruster_transmission">
+      <type>transmission_interface/SimpleTransmission</type>
+      <actuator name="${name}_motor">
+        <!-- Linear Mapping from force to actuator "effort" (motor command) such that
+             -->
+        <mechanicalReduction>1.35</mechanicalReduction>
+      </actuator>
+      <joint name="${name}_engine_propeller_joint">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      </joint>
+    </transmission>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
Depends on #355 

Load the thruster poses from the URDF, so they are not copied in two places.