### PR TITLE
BOOT: add use-imu1 flag for compatibility with newer sdgps version

### DIFF
--- a/scripts/bagging_variables.sh
+++ b/scripts/bagging_variables.sh
@@ -16,7 +16,6 @@ export BAG_DIR=~/bags
 # Topic variables that can be used from the bag command
 export bag_front_left_cam="/camera/front/left/camera_info /camera/front/left/image_raw"
 export bag_front_right_cam="/camera/front/right/camera_info /camera/front/right/image_raw"
-export bag_seecam="/camera/seecam/camera_info /camera/seecam/image_raw"
 export bag_front_cam="$bag_front_left_cam $bag_front_right_cam"
 export bag_starboard_cam="/camera/starboard/image_raw /camera/starboard/camera_info"
 export bag_down_cam="/camera/down/camera_info /camera/down/image_raw"

--- a/scripts/on_boot
+++ b/scripts/on_boot
@@ -9,7 +9,7 @@ SONAR_DIR="/home/$USER/sonar/software"
 # Command to connect to sylphase GPS/INS
 SDGPS="$SDGPS_DIR/build/main"
 ANTENNA_POSITION="[0.37465,-0.136525,0.587502]"
-GPS_CMD="(cd $SDGPS_DIR;sudo $SDGPS sylphase-usbgpsimu2 --antenna-position '$ANTENNA_POSITION' ! tracker ! kf2 --decimation 10 ! listen-solution-tcp 1234)"
+GPS_CMD="(cd $SDGPS_DIR;sudo $SDGPS sylphase-usbgpsimu2 --antenna-position '$ANTENNA_POSITION' --use-imu1 ! tracker ! kf2 --decimation 10 ! listen-solution-tcp 1234)"
 
 # Command to connect to sylphase passive sonar
 SONAR_CMD="$SONAR_DIR/softare/publish 7384"


### PR DESCRIPTION
* Now running on v0.10.1, this flag is needed for our older unit