### PR TITLE
MISSIONS: integrate thruster autodeploy / launcher into launch & missions

### DIFF
--- a/mission_control/navigator_launch/launch/hardware.launch
+++ b/mission_control/navigator_launch/launch/hardware.launch
@@ -7,6 +7,7 @@
   </include>
   <include unless="$(arg simulation)" file="$(find navigator_launch)/launch/hardware/velodyne.launch"/>
   <include file="$(find navigator_launch)/launch/hardware/kill_board.launch"/>
+  <include file="$(find navigator_launch)/launch/hardware/pneumatic_actuators.launch" />
   <!-- Disabled because sick is not on NaviGator -->
   <!-- include unless="$(arg simulation)" file="$(find navigator_launch/launch/hardware/sick_lidar.launch"/-->
 </launch>

--- a/mission_control/navigator_launch/launch/hardware/pneumatic_actuators.launch
+++ b/mission_control/navigator_launch/launch/hardware/pneumatic_actuators.launch
@@ -1,0 +1,21 @@
+<launch>
+    <node pkg="mil_pneumatic_actuator" type="pneumatic_actuator_node" name="actuator_driver" output="screen">
+        <!-- TODO: fix port name once it is actually setup -->
+        <param name="port" value="/dev/serial/by-id/usb-MIL_Data_Merge_Board_Ports_5_to_8_DMBP58-if00-port0"/>
+        <!-- TODO: fix ports once actually setup -->
+        <rosparam param="actuators">
+          FL_unlock: 1
+          FL_extend: 2
+          FL_retract: 3
+          FR_unlock: 4
+          FR_extend: 5
+          FR_retract: 6
+          BL_unlock: 7
+          BL_extend: 8
+          BL_retract: 9
+          BR_unlock: 10
+          BR_extend: 11
+          BR_retract: 12
+        </rosparam>
+    </node>
+</launch>

--- a/mission_control/navigator_launch/launch/hardware/pneumatic_actuators.launch
+++ b/mission_control/navigator_launch/launch/hardware/pneumatic_actuators.launch
@@ -1,21 +1,24 @@
 <launch>
     <node pkg="mil_pneumatic_actuator" type="pneumatic_actuator_node" name="actuator_driver" output="screen">
-        <!-- TODO: fix port name once it is actually setup -->
-        <param name="port" value="/dev/serial/by-id/usb-MIL_Data_Merge_Board_Ports_5_to_8_DMBP58-if00-port0"/>
-        <!-- TODO: fix ports once actually setup -->
+        <param name="port" value="/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AI02L380-if00-port0"/>
         <rosparam param="actuators">
-          FL_unlock: 1
-          FL_extend: 2
-          FL_retract: 3
-          FR_unlock: 4
-          FR_extend: 5
-          FR_retract: 6
-          BL_unlock: 7
-          BL_extend: 8
-          BL_retract: 9
-          BR_unlock: 10
-          BR_extend: 11
+          # ONLY BL has been verfied on navigator, others are not currently connected
+          BL_unlock: 1
+          BL_extend: 3
+          BL_retract: 4
+
+          # TODO: fix once it is all plugged in
+          FL_unlock: 5
+          FL_extend: 6
+          FL_retract: 7
+          FR_unlock: 8
+          FR_extend: 9
+          FR_retract: 10
+          BR_unlock: 11
+          BR_extend: 12
           BR_retract: 12
+
+          # TODO: valves for ball launcher
         </rosparam>
     </node>
 </launch>

--- a/mission_control/navigator_launch/launch/hardware/pneumatic_actuators.launch
+++ b/mission_control/navigator_launch/launch/hardware/pneumatic_actuators.launch
@@ -5,20 +5,37 @@
           # ONLY BL has been verfied on navigator, others are not currently connected
           BL_unlock: 1
           BL_extend: 3
-          BL_retract: 4
+          BL_retract: 2
 
           # TODO: fix once it is all plugged in
-          FL_unlock: 5
-          FL_extend: 6
-          FL_retract: 7
-          FR_unlock: 8
-          FR_extend: 9
-          FR_retract: 10
-          BR_unlock: 11
-          BR_extend: 12
-          BR_retract: 12
+          #FL_unlock: 5
+          #FL_extend: 6
+          #FL_retract: 7
+          #FR_unlock: 8
+          #FR_extend: 9
+          #FR_retract: 10
+          #BR_unlock: 11
+          #BR_extend: 12
+          #BR_retract: 12
 
           # TODO: valves for ball launcher
+          LAUNCHER_RELOAD:
+            type: set
+            ports:
+              open_port:
+                id: 4
+                default: False
+              close_port:
+                id: 5
+                default: False
+
+          LAUNCHER_FIRE:
+            type: pulse
+            pulse_time: 0.5
+            ports:
+              open_port:
+                id: 7
+                default: False
         </rosparam>
     </node>
 </launch>

--- a/mission_control/navigator_launch/package.xml
+++ b/mission_control/navigator_launch/package.xml
@@ -51,6 +51,7 @@
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>mil_passive_sonar</run_depend>
+  <run_depend>mil_pneumatic_actuator</run_depend>
   <export>
   </export>
 </package>

--- a/mission_control/navigator_missions/launch/task_runner.launch
+++ b/mission_control/navigator_missions/launch/task_runner.launch
@@ -2,5 +2,22 @@
     <node pkg="mil_tasks" type="task_runner" name="task_runner">
         <param name="tasks_module" value="navigator_missions" />
         <param name="base_task" value="Navigator" />
+        <rosparam>
+        actuator_timing:
+          # Time to wait for lock to engage when deploying thruster
+          deploy_lock_time: 0.5
+          # Time to wait for thruster to lower when deploying thruster
+          deploy_wait_time: 3.0
+          # Time to enable retract piston before unlocking when deploying a thruster
+          deploy_loosen_time: 1.0
+          # Time to wait for lock to engage when retracting thruster
+          retract_lock_time: 0.5
+          # Time to wait thruster to lift before engaging lock
+          retract_wait_time: 3.0
+          # Time to extend reload piston when reloading launcher
+          launcher_reload_extend_time: 5.0
+          # Time to retract reload piston when reloading launcher
+          launcher_reload_retract_time: 5.0
+        </rosparam>
     </node>
 </launch>

--- a/mission_control/navigator_missions/navigator_missions/__init__.py
+++ b/mission_control/navigator_missions/navigator_missions/__init__.py
@@ -23,4 +23,6 @@ from constant_velocity import ConstantVelocity
 from example_mission import ExampleMission
 from deploy_thrusters import DeployThrusters
 from retract_thrusters import RetractThrusters
+from fire_launcher import FireLauncher
+from reload_launcher import ReloadLauncher
 import pose_editor

--- a/mission_control/navigator_missions/navigator_missions/__init__.py
+++ b/mission_control/navigator_missions/navigator_missions/__init__.py
@@ -21,4 +21,6 @@ from killed import Killed
 from move import Move
 from constant_velocity import ConstantVelocity
 from example_mission import ExampleMission
+from deploy_thrusters import DeployThrusters
+from retract_thrusters import RetractThrusters
 import pose_editor

--- a/mission_control/navigator_missions/navigator_missions/deploy_thrusters.py
+++ b/mission_control/navigator_missions/navigator_missions/deploy_thrusters.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+from navigator import Navigator
+import txros
+from twisted.internet import defer
+
+
+class DeployThrusters(Navigator):
+    @txros.util.cancellableInlineCallbacks
+    def run(self, parameters):
+        self.send_feedback('Deploying thrusters')
+        yield self.deploy_thrusters()
+        defer.returnValue('Success')

--- a/mission_control/navigator_missions/navigator_missions/fire_launcher.py
+++ b/mission_control/navigator_missions/navigator_missions/fire_launcher.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+from navigator import Navigator
+import txros
+from twisted.internet import defer
+
+
+class FireLauncher(Navigator):
+    @txros.util.cancellableInlineCallbacks
+    def run(self, parameters):
+        yield self.fire_launcher()
+        defer.returnValue('Success')

--- a/mission_control/navigator_missions/navigator_missions/navigator.py
+++ b/mission_control/navigator_missions/navigator_missions/navigator.py
@@ -64,11 +64,15 @@ class Navigator(BaseTask):
     # Time to wait for thruster to lower when deploying thruster
     DEPLOY_WAIT_TIME = 3.0
     # Time to enable retract piston before unlocking when deploying a thruster
-    DEPLOY_LOOSEN_TIME = 0.25
+    DEPLOY_LOOSEN_TIME = 1.0
     # Time to wait for lock to engage when retracting thruster
     RETRACT_LOCK_TIME = 0.5
     # Time to wait thruster to lift before engaging lock
-    RETRACT_WAIT_TIME = 10.0
+    RETRACT_WAIT_TIME = 3.0
+    # Time to extend reload piston when reloading launcher
+    LAUNCHER_RELOAD_EXTEND_TIME = 5.0
+    # Time to retract reload piston when reloading launcher
+    LAUNCHER_RELOAD_RETRACT_TIME = 5.0
 
     def __init__(self, **kwargs):
         super(Navigator, self).__init__(**kwargs)
@@ -237,6 +241,16 @@ class Navigator(BaseTask):
         '''
 
         return defer.DeferredList([self.retract_thruster(name) for name in ['FL', 'FR', 'BL', 'BR']])
+
+    @util.cancellableInlineCallbacks
+    def reload_launcher(self):
+        yield self.set_valve('LAUNCH_RELOAD', True)
+        yield self.nh.sleep(self.LAUNCHER_RELOAD_EXTEND_TIME)
+        yield self.set_valve('LAUNCH_RELOAD', False)
+        yield self.nh.sleep(self.LAUNCHER_RELOAD_RETRACT_TIME)
+
+    def fire_launcher(self):
+        return self.set_valve('LAUNCHER_FIRE', True)
 
     def set_valve(self, name, state):
         req = SetValveRequest(actuator=name, opened=state)

--- a/mission_control/navigator_missions/navigator_missions/reload_launcher.py
+++ b/mission_control/navigator_missions/navigator_missions/reload_launcher.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+from navigator import Navigator
+import txros
+from twisted.internet import defer
+
+
+class ReloadLauncher(Navigator):
+    @txros.util.cancellableInlineCallbacks
+    def run(self, parameters):
+        yield self.reload_launcher()
+        defer.returnValue('Success')

--- a/mission_control/navigator_missions/navigator_missions/retract_thrusters.py
+++ b/mission_control/navigator_missions/navigator_missions/retract_thrusters.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+from navigator import Navigator
+import txros
+from twisted.internet import defer
+
+
+class RetractThrusters(Navigator):
+    @txros.util.cancellableInlineCallbacks
+    def run(self, parameters):
+        self.send_feedback('Retracting thrusters')
+        yield self.retract_thrusters()
+        defer.returnValue('Success')

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -28,15 +28,7 @@ nthrust()
 }
 _nthrust_complete()
 {
-    local THRUSTER
-    local THRUSTERS
-    THRUSTERS=(FL FR BL BR)
-    for THRUSTER in "${THRUSTERS[@]}"; do
-            # Skip any entry that does not match the string to complete
-            if [[ -z "$2" || ! -z "$(echo ${THRUSTER:0:${#2}} | grep $2)" ]]; then
-                            COMPREPLY+=( "$THRUSTER" )
-            fi
-    done
+		_list_complete "FL FR BL BR"
 }
 complete -F _nthrust_complete nthrust
 
@@ -47,21 +39,41 @@ alias nmove="runtask Move"
 # Wrench
 _nwrench_complete()
 {
-	local WRENCH
-	local WRENCHES
-	WRENCHES=( rc autonomous keyboard emergency )
-	for WRENCH in "${WRENCHES[@]}"; do
-		# Skip any entry that does not match the string to complete
-		if [[ -z "$2" || ! -z "$(echo ${WRENCH:0:${#2}} | grep $2)" ]]; then
-				COMPREPLY+=( "$WRENCH" )
-		fi
-	done
+  _list_complete "rc autonomous keyboard emergency"
 }
 nwrench()
 {
     rosservice call /wrench/select "topic: '$1'"
 }
 complete -F _nwrench_complete nwrench
+
+# Pneumatics
+_nvalve_complete()
+{
+	# Python oneliners are POWERFULL
+  # Get a list of all the actuator names and ids for autocompletion
+  ACTUATORS=$(python -c "import rospy; rospy.init_node('test', anonymous=True); param = rospy.get_param('/actuator_driver/actuators'); print ' '.join([key for key in param]) + ' ' + ' '.join([str(param[key]) for key in param if type(param[key]) == int])")
+
+  _list_complete "$ACTUATORS"
+}
+nvalveopen()
+{
+  rosservice call /actuator_driver/actuate "'$1'" true
+}
+complete -F _nvalve_complete nvalveopen
+
+nvalveclose()
+{
+  rosservice call /actuator_driver/actuate "'$1'" false
+
+}
+complete -F _nvalve_complete nvalveclose
+
+nvalvereset()
+{
+  rosservice call /actuator_driver/reset
+}
+
 
 # Alarms
 alias nhold="rosrun ros_alarms raise station-hold"

--- a/utils/remote_control/navigator_joystick_control/nodes/navigator_joystick.py
+++ b/utils/remote_control/navigator_joystick_control/nodes/navigator_joystick.py
@@ -35,6 +35,8 @@ class Joystick(object):
         self.last_emergency_control = False
         self.last_keyboard_control = False
         self.last_auto_control = False
+        self.thruster_deploy_count = 0
+        self.thruster_retract_count = 0
 
         self.start_count = 0
         self.last_joy = None
@@ -73,6 +75,9 @@ class Joystick(object):
         emergency_control = bool(joy.buttons[13])  # d-pad up
         keyboard_control = bool(joy.buttons[14])  # d-pad down
         auto_control = bool(joy.buttons[12])  # d-pad right
+        thruster_retract = bool(joy.buttons[4]) # LB
+        thruster_deploy = bool(joy.buttons[5]) # RB
+
 
         if back and not self.last_back:
             rospy.loginfo('Back pressed. Going inactive')
@@ -85,6 +90,22 @@ class Joystick(object):
             rospy.loginfo("Resetting controller state")
             self.reset()
             self.active = True
+
+        if thruster_retract:
+            self.thruster_retract_count += 1
+        else:
+            self.thruster_retract_count = 0
+        if thruster_deploy:
+            self.thruster_deploy_count += 1
+        else:
+            self.thruster_deploy_count = 0
+
+        if self.thruster_retract_count > 10:
+            self.remote.retract_thrusters()
+            self.thruster_retract_count = 0
+        elif self.thruster_deploy_count > 10:
+            self.remote.deploy_thrusters()
+            self.thruster_deploy_count = 0
 
         if not self.active:
             self.remote.clear_wrench()

--- a/utils/remote_control/navigator_joystick_control/nodes/navigator_joystick.py
+++ b/utils/remote_control/navigator_joystick_control/nodes/navigator_joystick.py
@@ -34,6 +34,7 @@ class Joystick(object):
         self.last_rc_control = False
         self.last_emergency_control = False
         self.last_keyboard_control = False
+        self.last_back = False
         self.last_auto_control = False
         self.thruster_deploy_count = 0
         self.thruster_retract_count = 0
@@ -75,9 +76,8 @@ class Joystick(object):
         emergency_control = bool(joy.buttons[13])  # d-pad up
         keyboard_control = bool(joy.buttons[14])  # d-pad down
         auto_control = bool(joy.buttons[12])  # d-pad right
-        thruster_retract = bool(joy.buttons[4]) # LB
-        thruster_deploy = bool(joy.buttons[5]) # RB
-
+        thruster_retract = bool(joy.buttons[4])  # LB
+        thruster_deploy = bool(joy.buttons[5])  # RB
 
         if back and not self.last_back:
             rospy.loginfo('Back pressed. Going inactive')

--- a/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
+++ b/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
@@ -17,6 +17,7 @@ from topic_tools.srv import MuxSelect
 from navigator_msgs.srv import ShooterManual
 import rospy
 from std_srvs.srv import Trigger, TriggerRequest
+from mil_tasks_core import TaskClient
 
 
 __author__ = "Anthony Olive"
@@ -36,6 +37,7 @@ class RemoteControl(object):
         self.station_hold_broadcaster = AlarmBroadcaster('station-hold')
 
         self.wrench_changer = rospy.ServiceProxy("/wrench/select", MuxSelect)
+        self.task_client = TaskClient()
         self.kill_listener = AlarmListener('kill', callback_funct=self._update_kill_status)
 
         if (wrench_pub is None):
@@ -119,6 +121,22 @@ class RemoteControl(object):
             problem_description="Request to station hold from remote control",
             parameters={'location': self.name}
         )
+
+    @_timeout_check
+    def deploy_thrusters(self, *args, **kwargs):
+        def cb(terminal_state, result):
+            # TODO(ironmig): check that it was actually succesful
+            rospy.loginfo('Thrusters deployed!')
+
+        self.task_client.run_task('DeployThrusters', done_cb=cb)
+
+    @_timeout_check
+    def retract_thrusters(self, *args, **kwargs):
+        def cb(terminal_state, result):
+            # TODO(ironmig): check that it was actually succesful
+            rospy.loginfo('Thrusters Retracted!')
+
+        self.task_client.run_task('RetractThrusters', done_cb=cb)
 
     @_timeout_check
     def select_autonomous_control(self, *args, **kwargs):

--- a/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
+++ b/utils/remote_control/navigator_keyboard_control/remote_control_lib/remote_control_lib.py
@@ -18,6 +18,7 @@ from navigator_msgs.srv import ShooterManual
 import rospy
 from std_srvs.srv import Trigger, TriggerRequest
 from mil_tasks_core import TaskClient
+from actionlib import TerminalState
 
 
 __author__ = "Anthony Olive"
@@ -125,16 +126,22 @@ class RemoteControl(object):
     @_timeout_check
     def deploy_thrusters(self, *args, **kwargs):
         def cb(terminal_state, result):
-            # TODO(ironmig): check that it was actually succesful
-            rospy.loginfo('Thrusters deployed!')
+            if terminal_state == 3:
+                rospy.loginfo('Thrusters Deployed!')
+            else:
+                rospy.logwarn('Error deploying thrusters: {}, status: {}'.format(
+                    TerminalState.to_string(terminal_state), result.status))
 
         self.task_client.run_task('DeployThrusters', done_cb=cb)
 
     @_timeout_check
     def retract_thrusters(self, *args, **kwargs):
         def cb(terminal_state, result):
-            # TODO(ironmig): check that it was actually succesful
-            rospy.loginfo('Thrusters Retracted!')
+            if terminal_state == 3:
+                rospy.loginfo('Thrusters Retracted!')
+            else:
+                rospy.logwarn('Error rectracting thrusters: {}, status: {}'.format(
+                    TerminalState.to_string(terminal_state), result.status))
 
         self.task_client.run_task('RetractThrusters', done_cb=cb)
 


### PR DESCRIPTION
depends on uf-mil/mil_common#135
closes #385 

The follow changes are added to support remote thruster deploy/retraction
* Launch the actuator driver with the configuration for the thrusters
* Write missions to actuate the valves to allow for thruster deploy/retraction
* Connect the LB and RB buttons on xbox controller to retract and deploy thrusters, respectively 