### PR TITLE
CAMERAS: fix front_left serial id and disable it

### DIFF
--- a/mission_control/navigator_launch/launch/hardware/cameras/front_cameras.launch
+++ b/mission_control/navigator_launch/launch/hardware/cameras/front_cameras.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="front_left"  default="True" />
+  <arg name="front_left"  default="False" />
   <arg name="front_right" default="True" />
   <arg name="simulation" default="False" />
   <include if="$(arg front_left)" file="$(find navigator_launch)/launch/hardware/cameras/front_left.launch">

--- a/mission_control/navigator_launch/launch/hardware/cameras/front_left.launch
+++ b/mission_control/navigator_launch/launch/hardware/cameras/front_left.launch
@@ -7,7 +7,7 @@
           args="manager" />
     <node pkg="nodelet" type="nodelet" name="front_left_camera_nodelet" unless="$(arg simulation)"
           args="load pointgrey_camera_driver/PointGreyCameraNodelet camera_nodelet_manager">
-          <param name="serial" value="15223364" />
+          <param name="serial" value="15223362" />
           <param name="camera_info_url" value="file://$(find navigator_launch)/config/camera_calibration/00b09d0100e84a44.yaml"/>
           <param name="frame_id" value="front_left_cam_optical"/>
           <param name="video_mode" value="format7_mode4"/>


### PR DESCRIPTION
At lakeday we discovered front_left has the wrong ID. Once it was fixed, we couldn't run front_left and starboard at same time (thank pointgrey), so disable front_left for now.