### PR TITLE
SIMULATION: add simulated pinger w/ ground truth heading

### DIFF
--- a/simulation/navigator_gazebo/CMakeLists.txt
+++ b/simulation/navigator_gazebo/CMakeLists.txt
@@ -36,6 +36,19 @@ add_dependencies(navigator_thrusters
   ${catkin_EXPORTED_TARGETS}
 )
 
+add_library(
+    pinger_plugin
+        src/pinger_plugin.cpp
+)
+set_target_properties(pinger_plugin PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
+target_link_libraries(pinger_plugin
+  ${catkin_LIBRARIES}
+  ${GAZEBO_LIBRARIES}
+)
+add_dependencies(pinger_plugin
+  ${catkin_EXPORTED_TARGETS}
+)
+
 add_library(sylphase_gazebo
   src/sylphase_gazebo.cpp
 )

--- a/simulation/navigator_gazebo/include/navigator_gazebo/pinger_plugin.hpp
+++ b/simulation/navigator_gazebo/include/navigator_gazebo/pinger_plugin.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ros/ros.h>
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <mutex>
+#include <vector>
+#include "gazebo/common/Assert.hh"
+#include "gazebo/common/Event.hh"
+#include "gazebo/common/Events.hh"
+#include "gazebo/common/Plugin.hh"
+#include "gazebo/math/Vector3.hh"
+#include "gazebo/physics/physics.hh"
+#include <std_srvs/Trigger.h>
+
+namespace navigator_gazebo
+{
+
+class PingerPlugin : public gazebo::ModelPlugin
+{
+public:
+  void Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _sdf) override;
+private:
+  bool ServiceCallback(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res);
+  std::string NewRandomGate();
+  ros::NodeHandle nh_;
+  ros::ServiceServer service_;
+  gazebo::physics::ModelPtr model_;
+};
+
+}

--- a/simulation/navigator_gazebo/include/navigator_gazebo/pinger_plugin.hpp
+++ b/simulation/navigator_gazebo/include/navigator_gazebo/pinger_plugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ros/ros.h>
+#include <std_srvs/Trigger.h>
 #include <algorithm>
 #include <cmath>
 #include <map>
@@ -12,15 +13,14 @@
 #include "gazebo/common/Plugin.hh"
 #include "gazebo/math/Vector3.hh"
 #include "gazebo/physics/physics.hh"
-#include <std_srvs/Trigger.h>
 
 namespace navigator_gazebo
 {
-
 class PingerPlugin : public gazebo::ModelPlugin
 {
 public:
   void Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _sdf) override;
+
 private:
   bool ServiceCallback(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res);
   std::string NewRandomGate();
@@ -28,5 +28,4 @@ private:
   ros::ServiceServer service_;
   gazebo::physics::ModelPtr model_;
 };
-
 }

--- a/simulation/navigator_gazebo/models/robotx_pinger/model.config
+++ b/simulation/navigator_gazebo/models/robotx_pinger/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>robotx_pinger</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Kevin Allen</name>
+    <email>todo</email>
+  </author>
+
+  <description>
+    Pinger for RobotX
+  </description>
+</model>

--- a/simulation/navigator_gazebo/models/robotx_pinger/model.sdf
+++ b/simulation/navigator_gazebo/models/robotx_pinger/model.sdf
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="robotx_pinger">
+    <static>true</static>
+    <pose>0 0 0 0 1.5708 0</pose>
+    <link name="link">
+      <visual name="visual">
+        <geometry>
+          <cylinder>
+            <radius>0.5</radius>
+            <length>0.001</length>
+          </cylinder>
+        </geometry>
+      </visual>
+    </link>
+    <plugin name="robotx_pinger_plugin" filename="libpinger_plugin.so" />
+  </model>
+</sdf>

--- a/simulation/navigator_gazebo/src/pinger_plugin.cpp
+++ b/simulation/navigator_gazebo/src/pinger_plugin.cpp
@@ -17,7 +17,8 @@ void PingerPlugin::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _sdf)
 bool PingerPlugin::ServiceCallback(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res)
 {
   std::string new_gate = NewRandomGate();
-  if (new_gate.empty()) {
+  if (new_gate.empty())
+  {
     res.success = false;
     res.message = "could not set gate, see ros error";
     return true;
@@ -32,7 +33,8 @@ std::string PingerPlugin::NewRandomGate()
   gazebo::math::Vector3 gates[3];
 
   gazebo::physics::ModelPtr entrance_gate = model_->GetWorld()->GetModel("robotx_2018_entrance_gate");
-  if (!entrance_gate) {
+  if (!entrance_gate)
+  {
     ROS_ERROR_NAMED("pinger_plugin", "Entrance gate model not found.");
     return "";
   }
@@ -43,14 +45,17 @@ std::string PingerPlugin::NewRandomGate()
   markers[2] = entrance_gate->GetLink("base_gate::white_buoy_right::link");
   markers[3] = entrance_gate->GetLink("base_gate::green_buoy::link");
 
-  for (size_t i = 0; i < 4; ++i) {
-    if (markers[i]) continue;
+  for (size_t i = 0; i < 4; ++i)
+  {
+    if (markers[i])
+      continue;
     ROS_ERROR_NAMED("pinger_plugin", "Marker %lu not found", i);
     return "";
   }
 
-  for (size_t i = 0; i < 3; ++i) {
-    gates[i] = (markers[i]->GetWorldPose().pos + markers[i+1]->GetWorldPose().pos) / 2.0;
+  for (size_t i = 0; i < 3; ++i)
+  {
+    gates[i] = (markers[i]->GetWorldPose().pos + markers[i + 1]->GetWorldPose().pos) / 2.0;
     gates[i].z = -5.0;
   }
 
@@ -62,6 +67,4 @@ std::string PingerPlugin::NewRandomGate()
   return std::to_string(random_selection + 1);
 }
 
-
-} // namespace navigator_gazebo
-
+}  // namespace navigator_gazebo

--- a/simulation/navigator_gazebo/src/pinger_plugin.cpp
+++ b/simulation/navigator_gazebo/src/pinger_plugin.cpp
@@ -1,0 +1,67 @@
+#include "navigator_gazebo/pinger_plugin.hpp"
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/math/Rand.hh>
+
+namespace navigator_gazebo
+{
+GZ_REGISTER_MODEL_PLUGIN(PingerPlugin)
+
+void PingerPlugin::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  model_ = _model;
+  nh_ = ros::NodeHandle("navigator_pinger_plugin");
+  service_ = nh_.advertiseService("/hydrophones/switch_gate", &PingerPlugin::ServiceCallback, this);
+  NewRandomGate();
+}
+
+bool PingerPlugin::ServiceCallback(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res)
+{
+  std::string new_gate = NewRandomGate();
+  if (new_gate.empty()) {
+    res.success = false;
+    res.message = "could not set gate, see ros error";
+    return true;
+  }
+  res.success = true;
+  res.message = "New Gate: " + new_gate;
+  return true;
+}
+
+std::string PingerPlugin::NewRandomGate()
+{
+  gazebo::math::Vector3 gates[3];
+
+  gazebo::physics::ModelPtr entrance_gate = model_->GetWorld()->GetModel("robotx_2018_entrance_gate");
+  if (!entrance_gate) {
+    ROS_ERROR_NAMED("pinger_plugin", "Entrance gate model not found.");
+    return "";
+  }
+
+  gazebo::physics::LinkPtr markers[4];
+  markers[0] = entrance_gate->GetLink("base_gate::red_buoy::link");
+  markers[1] = entrance_gate->GetLink("base_gate::white_buoy_left::link");
+  markers[2] = entrance_gate->GetLink("base_gate::white_buoy_right::link");
+  markers[3] = entrance_gate->GetLink("base_gate::green_buoy::link");
+
+  for (size_t i = 0; i < 4; ++i) {
+    if (markers[i]) continue;
+    ROS_ERROR_NAMED("pinger_plugin", "Marker %lu not found", i);
+    return "";
+  }
+
+  for (size_t i = 0; i < 3; ++i) {
+    gates[i] = (markers[i]->GetWorldPose().pos + markers[i+1]->GetWorldPose().pos) / 2.0;
+    gates[i].z = -5.0;
+  }
+
+  int random_selection = gazebo::math::Rand::GetIntUniform(0, 2);
+  gazebo::math::Pose new_pose(gates[random_selection], gazebo::math::Quaternion());
+
+  model_->SetWorldPose(new_pose);
+
+  return std::to_string(random_selection + 1);
+}
+
+
+} // namespace navigator_gazebo
+

--- a/simulation/navigator_gazebo/urdf/navigator.urdf.xacro
+++ b/simulation/navigator_gazebo/urdf/navigator.urdf.xacro
@@ -15,8 +15,7 @@
                     xyz="-0.277622 0 0.648208" rpy="0 0 0" />
   <xacro:fixed_link name="sick" parent="measurement"
                     xyz="0.5334 -0.0254 -0.6858" rpy="0 0 0" />
-  <xacro:fixed_link name="hydrophones" parent="measurement"
-                    xyz="-1.1303 -.635 -1.524" rpy="0 0 0" />
+
   <xacro:fixed_link name="pinger_direction" parent="velodyne"
                     xyz="0.8382 0 -2.0828" rpy="0 0 0" />
 
@@ -50,7 +49,14 @@
       <thruster>FL</thruster>
       <thruster>FR</thruster>
     </plugin>
+    <plugin name="pinger_heading_ground_truth" filename="libmil_model_heading.so">
+      <topic>/hydrophones/direction</topic>
+      <model>robotx_pinger</model>
+      <offset>0.102 -.635 -0.324 0 0 0</offset>
+    </plugin>
   </gazebo>
+  <xacro:fixed_link name="hydrophones" parent="base_link"
+                    xyz="0.102 -.635 -0.324" rpy="0 0 0" />
 
   <xacro:include filename="$(find wamv_gazebo)/urdf/macros.xacro" />
   <!-- Attach hydrodynamics plugin -->

--- a/simulation/navigator_gazebo/worlds/course.world.xacro
+++ b/simulation/navigator_gazebo/worlds/course.world.xacro
@@ -24,6 +24,11 @@
       <pose>80 -8.75 0 0 0 0</pose>
     </include>
 
+    <include>
+      <uri>model://robotx_pinger</uri>
+      <pose>55 -50 0 0 0 -1.3</pose>
+    </include>
+
     <!-- The 2018 dock with the two placards -->
     <include>
       <uri>model://dock_2018</uri>


### PR DESCRIPTION
depends on uf-mil/mil_common#139

Adds a pinger to gazebo. you can call a service to switch which gate it's in and it will publish a heading from NaviGator to the heading (using ground truth so high level mission code can be tested)