### PR TITLE
Controller

### DIFF
--- a/hardware_drivers/navigator_kill_board/navigator_kill_board/constants.py
+++ b/hardware_drivers/navigator_kill_board/navigator_kill_board/constants.py
@@ -101,15 +101,16 @@ constants = {
                            # Joystick message is 3 signed ints from -2048 to 2047
                            # Button message is 16 bits signifying up to 16 buttons on/off
     'CTRL_STICKS': ['UD', 'LR', 'TQ'],  # Up/Down, Left/Right, Torque
-    'CTRL_BUTTONS': ['X', 'Y', 'A', 'B', 'DL', 'DR', 'START'],
+    'CTRL_BUTTONS': ['STATION_HOLD', 'RAISE_KILL', 'CLEAR_KILL', 'THRUSTER_RETRACT',\
+                     'THRUSTER_DEPLOY', 'GO_INACTIVE', 'START', 'EMERGENCY_CONTROL'],
     'CTRL_BUTTONS_VALUES': {  # Amount of buttons and labels will be changed in the future
-                              # This currently mimics xbox controller labels and numbering
-        'X': '\x00\x04',  # Button 2
-        'Y': '\x00\x08',  # Button 3
-        'A': '\x00\x01',  # Button 0
-        'B': '\x00\x02',  # Button 1
-        'DL': '\x08\x00',  # Dpad Left (Button 11)
-        'DR': '\x10\x00',  # Dpad Right (Button 12)
-        'START': '\x00\x80',  # Start (Button 7)
+        'STATION_HOLD': '\x00\x01',  # Button 0
+        'RAISE_KILL': '\x00\x02',  # Button 1
+        'CLEAR_KILL': '\x00\x04',  # Button 2
+        'THRUSTER_RETRACT': '\x00\x10',  # Button 4
+        'THRUSTER_DEPLOY': '\x00\x20',  # Button 5
+        'GO_INACTIVE': '\x00\x40',  # Button 6
+        'START': '\x00\x80',  # Button 7
+        'EMERGENCY_CONTROL': '\x20\x00',  # Button 13
     }
 }

--- a/hardware_drivers/navigator_kill_board/nodes/kill_board_driver.py
+++ b/hardware_drivers/navigator_kill_board/nodes/kill_board_driver.py
@@ -256,13 +256,14 @@ class KillInterface(object):
         current_joy.axes[0] = np.float32(self.sticks['LR']) / 2048
         current_joy.axes[1] = np.float32(self.sticks['UD']) / 2048
         current_joy.axes[3] = np.float32(self.sticks['TQ']) / 2048
+        current_joy.buttons[0] = np.int32(self.buttons['STATION_HOLD'])
+        current_joy.buttons[1] = np.int32(self.buttons['RAISE_KILL'])
+        current_joy.buttons[2] = np.int32(self.buttons['CLEAR_KILL'])
+        current_joy.buttons[4] = np.int32(self.buttons['THRUSTER_RETRACT'])
+        current_joy.buttons[5] = np.int32(self.buttons['THRUSTER_DEPLOY'])
+        current_joy.buttons[6] = np.int32(self.buttons['GO_INACTIVE'])
         current_joy.buttons[7] = np.int32(self.buttons['START'])
-        current_joy.buttons[3] = np.int32(self.buttons['Y'])
-        current_joy.buttons[2] = np.int32(self.buttons['X'])
-        current_joy.buttons[0] = np.int32(self.buttons['A'])
-        current_joy.buttons[1] = np.int32(self.buttons['B'])
-        current_joy.buttons[11] = np.int32(self.buttons['DL'])  # Dpad Left
-        current_joy.buttons[12] = np.int32(self.buttons['DR'])  # Dpad Right
+        current_joy.buttons[13] = np.int32(self.buttons['EMERGENCY_CONTROL'])
         current_joy.header.frame_id = "/base_link"
         current_joy.header.stamp = rospy.Time.now()
         self.joy_pub.publish(current_joy)

--- a/hardware_drivers/navigator_kill_board/nodes/kill_board_driver.py
+++ b/hardware_drivers/navigator_kill_board/nodes/kill_board_driver.py
@@ -253,8 +253,8 @@ class KillInterface(object):
         for stick in self.sticks:
             if self.sticks[stick] >= 0x8000:  # Convert 2's complement hex to signed decimal if negative
                 self.sticks[stick] -= 0x10000
-        current_joy.axes[0] = np.float32(self.sticks['UD']) / 2048
-        current_joy.axes[1] = np.float32(self.sticks['LR']) / 2048
+        current_joy.axes[0] = np.float32(self.sticks['LR']) / 2048
+        current_joy.axes[1] = np.float32(self.sticks['UD']) / 2048
         current_joy.axes[3] = np.float32(self.sticks['TQ']) / 2048
         current_joy.buttons[7] = np.int32(self.buttons['START'])
         current_joy.buttons[3] = np.int32(self.buttons['Y'])

--- a/utils/remote_control/navigator_emergency_control/nodes/navigator_emergency.py
+++ b/utils/remote_control/navigator_emergency_control/nodes/navigator_emergency.py
@@ -32,17 +32,17 @@ class Joystick(object):
         Used to reset the state of the controller. Sometimes when it
         disconnects then comes back online, the settings are all out of whack.
         '''
-        self.last_kill = False
+        self.last_raise_kill = False
+        self.last_clear_kill = False
         self.last_station_hold_state = False
-        self.last_auto_control = False
         self.last_emergency_control = False
-        self.last_shooter_cancel = False
-        self.last_change_mode = False
+        self.last_go_inactive = False
+        self.thruster_deploy_count = 0
+        self.thruster_retract_count = 0
 
         self.start_count = 0
         self.last_joy = None
         self.active = False
-
         self.remote.clear_wrench()
 
     def check_for_timeout(self, joy):
@@ -70,48 +70,62 @@ class Joystick(object):
 
         # Assigns readable names to the buttons that are used
         start = joy.buttons[7]
-        kill = bool(joy.buttons[2])
+        go_inactive = joy.buttons[6]
+        raise_kill = bool(joy.buttons[1])
+        clear_kill = bool(joy.buttons[2])
         station_hold = bool(joy.buttons[0])
-        emergency_control = bool(joy.buttons[11])
-        auto_control = bool(joy.buttons[12])
-        shooter_cancel = bool(joy.buttons[1])
-        change_mode = bool(joy.buttons[3])
+        emergency_control = bool(joy.buttons[13])
+        thruster_retract = bool(joy.buttons[4])
+        thruster_deploy = bool(joy.buttons[5])
 
-        # Reset controller state if only start is pressed down about 3 seconds
+        if go_inactive and not self.last_go_inactive:
+            rospy.loginfo('Back pressed. Going inactive')
+            self.reset()
+        return
+
+        # Reset controller state if only start is pressed down about 1 seconds
         self.start_count += start
-        if self.start_count > 10:
+        if self.start_count > 5:
             rospy.loginfo("Resetting controller state")
             self.reset()
             self.active = True
-            self.remote.clear_kill()
+
+        if thruster_retract:
+            self.thruster_retract_count += 1
+        else:
+            self.thruster_retract_count = 0
+        if thruster_deploy:
+            self.thruster_deploy_count += 1
+        else:
+            self.thruster_deploy_count = 0
+
+        if self.thruster_retract_count > 10:
+            self.remote.retract_thrusters()
+            self.thruster_retract_count = 0
+        elif self.thruster_deploy_count > 10:
+            self.remote.deploy_thrusters()
+            self.thruster_deploy_count = 0
 
         if not self.active:
             return
 
-        if kill and not self.last_kill:
-            self.remote.toggle_kill()
+        if raise_kill and not self.last_raise_kill:
+            self.remote.kill()
+
+        if clear_kill and not self.last_clear_kill:
+            self.remote.clear_kill()
 
         if station_hold and not self.last_station_hold_state:
             self.remote.station_hold()
 
-        if auto_control and not self.last_auto_control:
-            self.remote.select_autonomous_control()
-
         if emergency_control and not self.last_emergency_control:
             self.remote.select_emergency_control()
 
-        if shooter_cancel and not self.last_shooter_cancel:
-            self.remote.shooter_cancel()
-
-        if change_mode and not self.last_change_mode:
-            self.remote.select_next_control()
-
-        self.last_kill = kill
+        self.last_raise_go_inactive = go_inactive
+        self.last_raise_kill = raise_kill
+        self.last_clear_kill = clear_kill
         self.last_station_hold_state = station_hold
-        self.last_auto_control = auto_control
         self.last_emergency_control = emergency_control
-        self.last_shooter_cancel = shooter_cancel
-        self.last_change_mode = change_mode
 
         # Scale joystick input to force and publish a wrench
         x = joy.axes[1] * self.force_scale


### PR DESCRIPTION
KILL BOARD: update emergency controller functionality

- Update emergency controller node to have raise/clear kill buttons (no longer toggle). Remove autonomous, wrench toggle, and shooter functionality. Remove clear kill from controller startup.

- Update kill board constants for similar functionality to xbox controller, and change interpretation of "button bytes" from incoming messages from emergency controller to reflect updated functions.

- Update kill board node to match new constants and functionality. Change interpretation of incoming message joystick bytes such that the software's 'x axis' corresponds to joystick forward/back and 'y axis' corresponds to joystick left/right.