### PR TITLE
ALARMS: disable software network kill

### DIFF
--- a/mission_control/navigator_launch/launch/alarms.launch
+++ b/mission_control/navigator_launch/launch/alarms.launch
@@ -8,7 +8,7 @@
     </rosparam>
   </node>
   <rosparam ns="meta_alarms">
-    kill: ['odom-kill', 'network-loss', 'hw-kill']
+    kill: ['odom-kill', 'hw-kill']
   </rosparam>
   <rosparam ns="known_alarms">
     kill, odom-kill, network-loss, station-hold, battery-voltage, hw-kill, thruster-fault


### PR DESCRIPTION
Required to be able to use emergency controller when ubiquity network is failing. Otherwise the network-loss alarm would raise.